### PR TITLE
Add step reference to build and push the container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Past this check, the process becomes automated by running a set of targets provi
 2. Delete the contents of the old chart in `helm-charts/orchestrator` to ensure only the new chart manifests are used.
 3. Copy the new chart manifests over `helm-charts/orchestrator`.
 4. Ensure that the resources in the charts are aligned with the RBAC granted to the operator in the `config/rbac/role.yaml` file. This step can be expedited by determining the differences between the existing and new version of the chart, which resources have been added and which ones have been removed and, most importantly, what is the access required (CRUD).
-5. Test the deployment of the new version of the operator in a new cluster. Use the `make run` to run the operator locally while connected to a live cluster using your current credentials, or deploy as a pod with the command `IMAGE_TAG_BASE=<location of the container image in registry> make docker-build docker-push deploy`. Remember that changes to the `config/rbac/role.yaml` file are only reflected when the operator is deployed as a pod.
-6. Once the new version has been validated, run the `make docker-build docker-push` command using the default `IMAGE_TAG_BASE` so that it is published to the registry.
-7. Run the following command `make bundle bundle-build bundle-push catalog-build catalog-push`. This command will update the operator's manifest and generate the container images required by OLM.
-8. Create a new PR and merge the changes to the repository.
-9. Tag the new version in GitHub after the PR is merged.
+5. Generate the new container images and push them `make docker-build docker-push`.
+6. Test the deployment of the new version of the operator in a new cluster. Use the `make run` to run the operator locally while connected to a live cluster using your current credentials, or deploy as a pod with the command `IMAGE_TAG_BASE=<location of the container image in registry> make docker-build docker-push deploy`. Remember that changes to the `config/rbac/role.yaml` file are only reflected when the operator is deployed as a pod.
+7. Once the new version has been validated, run the `make docker-build docker-push` command using the default `IMAGE_TAG_BASE` so that it is published to the registry.
+8. Run the following command `make bundle bundle-build bundle-push catalog-build catalog-push`. This command will update the operator's manifest and generate the container images required by OLM.
+9. Create a new PR and merge the changes to the repository.
+10. Tag the new version in GitHub after the PR is merged.


### PR DESCRIPTION
Add step in the README.md to include a reference to build the container image and push it to the quay.io registry as part of the upgrade process.

@masayag PTAL.