### PR TITLE
[FLPATH-1240] Print readiness and status when listing CRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.2
+VERSION ?= 0.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -86,10 +86,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-04T19:03:27Z"
+    createdAt: "2024-04-17T17:09:04Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
-  name: orchestrator-operator.v0.0.2
+  name: orchestrator-operator.v0.0.3
   namespace: openshift-operators
 spec:
   apiservicedefinitions: {}
@@ -452,4 +452,4 @@ spec:
   provider:
     name: Red Hat
     url: https://parodos.dev
-  version: 0.0.2
+  version: 0.0.3

--- a/bundle/manifests/orchestrator.parodos.dev_orchestrators.yaml
+++ b/bundle/manifests/orchestrator.parodos.dev_orchestrators.yaml
@@ -12,7 +12,14 @@ spec:
     singular: orchestrator
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Deployed')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Deployed')].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Orchestrator is the Schema for the orchestrators API

--- a/config/crd/bases/orchestrator.parodos.dev_orchestrators.yaml
+++ b/config/crd/bases/orchestrator.parodos.dev_orchestrators.yaml
@@ -12,7 +12,14 @@ spec:
     singular: orchestrator
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Deployed')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Deployed')].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Orchestrator is the Schema for the orchestrators API


### PR DESCRIPTION
In an effort to address https://issues.redhat.com/browse/FLPATH-1240 I noticed that listing the CR instances only included the NAME column and did not include the status and reason columns, which add verbosity to the user about the state of the CRs. This PR adds these new columns (READY and REASON) when listing the orchestrator CRs to look like the following:

```
$> kubectl get orchestrators.orchestrator.parodos.dev
NAME     READY   REASON
sample   True    InstallSuccessful
```

I have already generated version v.0.0.3 of the bundle and catalog. You will need to delete your instance of the CRD and point to version 0.0.3 of the container images to be able to benefit from this change.

@masayag @chadcrum PTAL.