### PR TITLE
FLT-1300: Show all status and reasons when listing the CR

### DIFF
--- a/config/crd/bases/orchestrator.parodos.dev_orchestrators.yaml
+++ b/config/crd/bases/orchestrator.parodos.dev_orchestrators.yaml
@@ -13,10 +13,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Deployed')].status
+    - jsonPath: .status.conditions[-1:].status
       name: Ready
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Deployed')].reason
+    - jsonPath: .status.conditions[-1:].reason
       name: Reason
       type: string
     name: v1alpha1


### PR DESCRIPTION
Show the last entry in the conditions slice rather than filter by type being `Deployed`:
Example of the output once the CRD has been updated:
```
$> oc get orchestrators.orchestrator.parodos.dev  -w 
NAME     READY   REASON
sample   True    InstallError
sample   True    InstallError
sample
sample   True    InstallError
sample   True    InstallError
sample   True    InstallSuccessful
```

@masayag @chadcrum PTAL.