### PR TITLE
Add controller digest in bundle.konflux.Dockerfile and updated tekton pipeline run conditions

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ( "bundle.konflux.Dockerfile".pathChanged() || ".tekton/bundle-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: helm-operator

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ( "bundle.konflux.Dockerfile".pathChanged() || ".tekton/bundle-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: helm-operator

--- a/.tekton/controller-pull-request.yaml
+++ b/.tekton/controller-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ( "Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "helm-charts/***".pathChanged() || ".tekton/controller-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: helm-operator

--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ( "Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "helm-charts/***".pathChanged() || ".tekton/controller-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: helm-operator

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9:latest as builder
-ARG IMG=quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller@sha256:3b0a41d9e01bc357bf6b6c2804aab0d94a03c4fe38102728ee9e144b6100eced
+ARG IMG=quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller@sha256:47b07a1098c23ad0e5f6166cd8b95bfc3bb0f90675753ef98fa3905e5a7c7ab6
 WORKDIR /operator
 COPY . .
 RUN dnf install make -y && make bundle IMG=${IMG}

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9:latest as builder
 ARG IMG=quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller@sha256:3b0a41d9e01bc357bf6b6c2804aab0d94a03c4fe38102728ee9e144b6100eced
 WORKDIR /operator
 COPY . .
-RUN dnf install make && make bundle IMG=${IMG}
+RUN dnf install make -y && make bundle IMG=${IMG}
 
 FROM scratch
 

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,9 +1,8 @@
 FROM registry.access.redhat.com/ubi9:latest as builder
-
+ARG IMG=quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller@sha256:3b0a41d9e01bc357bf6b6c2804aab0d94a03c4fe38102728ee9e144b6100eced
 WORKDIR /operator
 COPY . .
-RUN dnf install make -y && make bundle
-
+RUN dnf install make && make bundle IMG=${IMG}
 
 FROM scratch
 


### PR DESCRIPTION
* Added the controller image with digest in the `bundle.konflux.Dockerfile` to be used as a CLI argument when running the `bundle` target in the Makefile. Using the image digest also enables the nudge feature in Konflux to create a PR that updates the value on each controller image build. Once a new controller digest is available, Konflux will create a PR that targets the Dockerfile in this case and its only change is the digest value so that it references the latest one. Merging the PR 

* Updated tekton pipeline run conditions so that each pipeline only runs when changes occur on certain files that impact the image it generates.

@masayag @rgolangh PTAL.