### PR TITLE
Revert "Bump operator-sdk from 1.33.0 to 1.35.0 in Makefile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.35.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)


### PR DESCRIPTION
This reverts commit 087c6ac65a0b34dc9cb371e13391621f096f3a34.