### PR TITLE
Add a label with controller's pullspec to the bundle's containerfile 

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -8,6 +8,9 @@ FROM scratch
 
 USER 1001
 
+# Expose controller's container image with digest so that we can retrieve it with skopeo when creating the FBC catalog
+LABEL controller="quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/operator-controller@sha256:b1a88644ad07f3717fb00f1db0c8a20d8cadfc434e9e07a0c9cbf7be47c40783"
+
 # Required labels
 LABEL com.redhat.component="RHDH Orchestrator Helm Operator"
 LABEL distribution-scope="public"


### PR DESCRIPTION
This label can be used to determine the controller's image pullspec match directly from the bundle container image, and use it to validate that the snapshot controller's image is the same as the one in the label.