### PR TITLE
Add documentation for releasing with Konflux (staging and production)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Meta Operator for deploying the Orchestrator helm charts
 # Installing the operator
 Please visit the [README.md](https://github.com/parodos-dev/orchestrator-helm-operator/blob/gh-pages/README.md) page and follow the guide to install the operator in your cluster.
 
-## Release
+## Releasing the operator
+
+# Preparing the code for releasing
 
 Follow these steps to release a new version of the operator:
 
@@ -15,15 +17,24 @@ Follow these steps to release a new version of the operator:
 1. Create a new PR against main, unless the changes are targeting a specific release.
 1. Get the PR reviewed by the owner of the changes to the chart or by another team member. Two more pair of eyes are always welcome for these kind of things.
 1. Merge the PR.
+
+At this point releasing the operator can branch into 2 scenarios:
+* Manual release for local consumption. This kind of releases are only meant to be used for local development or earlly QE testing, not for general consumption in the RH catalog.
+* Konflux managed release for staging and production environments. It uses the Konflux pipelines to bundle the images to the Red Hat Operator Ecosystems Catalog.
+
+## Konflux release (for downstream)
+
+Follow the [konflux release documentation](docs/release_operator_with_konflux.md) for staging and production releases using Konflux.
+
+## Manual release (for upstream only)
 1. Switch to the main branch and pull the changes so that your fork and upstream are in sync and contain the new additions.
 1. Run the following commands in an AMD64 environment.	These commands will build the controller image, push it to the `quay.io/orchestrator/orchestrator-operator` [repository](https://quay.io/repository/orchestrator/orchestrator-operator?tab=tags), build the bundle (update the contents of `/bundle` based on the information in `/config`), build the bundle image and push it to the [repository](https://quay.io/repository/orchestrator/orchestrator-operator-bundle?tab=tags), and finally build the catalog container image and push it to it's [repository](https://quay.io/repository/orchestrator/orchestrator-operator-catalog?tab=tags).
-
 ```shell
 make docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push
 ```
 
-10. Navigate to the [catalog repository](https://quay.io/repository/orchestrator/orchestrator-operator-catalog?tab=tags) and locate the latest build image. The last modified value should give it away but worth checking just in case the push failed (e.g. podman could not authenticate against quay.io because credentials have expired).
-10. Retrieve the SHA256 digest (e.g. `sha256:0aff5f6dfdd0eb25ca81f6b6aceee98bff8737b507632733e2d44f1821518e1e` ) and create a new catalog source manifest that points to that new image:
+3. Navigate to the [catalog repository](https://quay.io/repository/orchestrator/orchestrator-operator-catalog?tab=tags) and locate the latest build image. The last modified value should give it away but worth checking just in case the push failed (e.g. podman could not authenticate against quay.io because credentials have expired). In these cases, retry pushing the images manually.
+3. Retrieve the SHA256 digest (e.g. `sha256:0aff5f6dfdd0eb25ca81f6b6aceee98bff8737b507632733e2d44f1821518e1e` ) and create a new catalog source manifest that points to that new image:
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
@@ -41,6 +52,6 @@ spec:
     registryPoll:
       interval: 10m
 ```
-12. Deploy the catalogsource in your cluster and ensure that the latest version in the OLM menu for the orchestrator operator matches with the new version of the operator.
-12. Install the operator and create a sample CR. Validate the CR deploys successfully by checking its status. You can take it further a notch and validate that the related objects also successfully deploy.
-12. Share the new manfiest in the development channel to announce the new release. Tag the QE team so that they are aware and can take action as soon as they are able.
+5. Deploy the catalogsource in your cluster and ensure that the latest version in the OLM menu for the orchestrator operator matches with the new version of the operator.
+5. Install the operator and create a sample CR. Validate the CR deploys successfully by checking its status. You can take it further a notch and validate that the related objects also successfully deploy.
+5. Share the new manfiest in the development channel to announce the new release. Tag the QE team so that they are aware and can take action as soon as they are able.

--- a/doc/imagedigestmirrorset.yaml
+++ b/doc/imagedigestmirrorset.yaml
@@ -1,0 +1,12 @@
+kind: ImageDigestMirrorSet
+apiVersion: config.openshift.io/v1
+metadata:
+  name: orchestrator-operator-fbc-staging-index
+spec:
+  imageDigestMirrors:
+    - source: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle
+      mirrors:
+        - registry.stage.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle
+    - source: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/controller-rhel9-operator
+      mirrors:
+        - registry.stage.redhat.io/rhdh-orchestrator-dev-preview-beta/controller-rhel9-operator

--- a/doc/release_operator_with_konflux.md
+++ b/doc/release_operator_with_konflux.md
@@ -1,0 +1,464 @@
+# Release the operator (for OCP) with Konflux
+
+## Prerequisites:
+To be able to release the operator, you will need first to have access to the orchestrator-releng workspace in konflux via the [Red Hat Console](https://console.redhat.com). If you don't, please reach out to @jordigilh, @masayag, @rgolangh or @pkliczewski to request access. You'll also need to be able to create PRs to the [orchestrator-helm-operator](https://github.com/parodos-dev/orchestrator-helm-operator) and [orchestrator-fbc](https://github.com/parodos-dev/orchestrator-fbc) repositories.
+
+Accessing the Konflux cluster via oc CLI requires an auth token from the OCP. Once you've been added to the `orchestrator-releng` workspace, head to [this URL](https://oauth-openshift.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/oauth/token/request) to obtain a new token and login to the
+Konflux cluster.
+
+## Introduction
+Releasing the operator is a 3 stage operation:
+* Build the images using Konflux's pipelines to your workspace environment
+* Release these images to the staging repository. The images are basically inspected based on predefined rules by Konflux and deposited to the staging repository upon success.
+* Release the [FBC](https://docs.openshift.com/container-platform/4.17/extensions/catalogs/fbc.html) (File Based Catalog) fragment to the RH catalog staging index using the pullspec of the images pushed to the staging registry.
+
+Production releases builds on top of the staging releases to do more or less the same, except that in this case it goes though a more detailed scrutity, ending up in the production registry. Past this step, it's the same FBC graph generation using the image pullspec in production.
+
+## Staging release
+
+### Releasing container images to the staging registry
+* Filter the latest snapshot. Keep in mind that we need to filter based on the bundle push event since that will most probably contain the nudged update from the controller. The following commands sorts all the snapshots for the helm-operator application by timestamp in ascending order and displays the name, integration tests success status and the merge PR number and remote branch used in the commit:
+```console
+oc get snapshots --sort-by .metadata.creationTimestamp -l pac.test.appstudio.openshift.io/event-type=push,appstudio.openshift.io/component=orchestrator-operator-bundle -ojsonpath='{range .items[*]}{@.metadata.name}{"\t"}{@.status.conditions[?(@.type=="AppStudioTestSucceeded")].status}{"\t"}{@.metadata.annotations.pac\.test\.appstudio\.openshift\.io/sha-title}{"\n"}{end}'
+```
+
+Example:
+```console
+helm-operator-v2wsd		False	Merge pull request #170 from parodos-dev/appstudio-orchestrator-operator-bundle
+helm-operator-hds86		False	Merge pull request #173 from jordigilh/migrate/doc_from_helm_charts
+helm-operator-gsbw7		False	Merge pull request #176 from parodos-dev/konflux-purge-operator-controller
+helm-operator-2t79j		False	Merge pull request #177 from parodos-dev/konflux-purge-operator-bundle
+helm-operator-rtrjw		False	Merge pull request #183 from parodos-dev/appstudio-controller-rhel9-operator
+helm-operator-kbzh5		False	Merge pull request #182 from parodos-dev/appstudio-orchestrator-operator-bundle
+helm-operator-kr8xs		False	Merge pull request #178 from jordigilh/konflux/use_comet_image_names_in_tekton
+helm-operator-kpxfn		False	Merge pull request #184 from parodos-dev/konflux/references/main
+helm-operator-pddv7		False	Merge pull request #191 from parodos-dev/appstudio-controller-rhel9-operator
+helm-operator-lbsdg		False	Merge pull request #189 from parodos-dev/appstudio-orchestrator-operator-bundle
+helm-operator-m4bkb		False	Merge pull request #187 from jordigilh/konflux/fix_build_attestation
+helm-operator-z26kc		True	Merge pull request #194 from jordigilh/release/1.2.0-rc11
+helm-operator-6mhqg		True	Merge pull request #195 from parodos-dev/konflux/component-updates/controller-rhel9-operator
+helm-operator-f949l		True	Merge pull request #196 from parodos-dev/konflux/references/main
+helm-operator-zpds7		True	Merge pull request #197 from jordigilh/konflux/add_label_controller_pullspec_to_bundle_dockerfile
+```
+
+If you're releasing from a controller's update nudge, which is the most probable case, check the last snapshot that has passed the integration tests and has a remote branch that looks like this `parodos-dev/konflux/component-updates/controller-rhel9-operator`, like this entry:
+```console
+helm-operator-6mhqg		True	Merge pull request #195 from parodos-dev/konflux/component-updates/controller-rhel9-operator
+```
+
+* Ensure that the bundle's controller pullspec matches the one in the snapshot. The bundle's container image contains a label with the image pullspec of the controller used in the bundle. Use the following commands to extract the controler from the bundle of the snapshot `helm-operator-6mhqg`:
+```console
+snapshot=helm-operator-6mhqg
+bundle=$(oc get snapshot $snapshot -ojsonpath='{.spec.components[?(@.name=="orchestrator-operator-bundle")].containerImage}')
+controllerInBundle=$(skopeo inspect docker://$bundle --format "{{.Labels.controller}}")
+controllerInSnapshot=$(oc get snapshot $snapshot -ojsonpath='{.spec.components[?(@.name=="controller-rhel9-operator")].containerImage}')
+if [ "$controllerInBundle"=="$controllerInSnapshot" ]; then echo "controller image pullspec matches";else echo "controller image pullspec does not match. This snapshot is not a good candidate for release";fi
+```
+
+* Create a new Release manifest for staging
+```console
+releaseName=$(bash -c "oc create -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  generateName: helm-operator-staging-
+  namespace: orchestrator-releng-tenant
+spec:
+  releasePlan: helm-operator-staging
+  snapshot: $snapshot
+EOF" | awk '{print $1}')
+```
+
+* Wait for the release to be validated:
+```console
+while [ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Progressing" ];do sleep 5;done
+[[ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Failed" ]] && echo Release failed: $(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].message}') || echo "Release successful"
+```
+
+If the release fails, follow the [troubleshooting](#release-pipeline-failed) guide to find out the root cause.
+
+* Validate that the container images are in the staging registry by inspecting them with skopeo. The pullspec of the images are defined in the advisory manifest:
+
+```console
+advisoryURL=$(oc get $releaseName -n rhtap-releng-tenant -ojsonpath='{.status.artifacts.advisory.url}' | sed  's/blob/raw/')
+controllerPullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("controller-rhel9-operator$") ))| .[].containerImage')
+bundlePullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("orchestrator-operator-bundle$") ))| .[].containerImage')
+skopeo inspect docker://$controllerPullSpec >/dev/null && echo "Controller image found in $controllerPullSpec" || echo "Controller image not found in $controllerPullSpec"
+skopeo inspect docker://$bundlePullSpec >/dev/null && echo "Bundle image found in $bundlePullSpec" || echo "Controller image not found in $bundlePullSpec"
+```
+
+At this point we can confirm that we have a successful release of the images and that they are ready to be used to release a new FBC version.
+
+### Releasing a new FBC Index
+To release a new version of the operator in the Red Hat Catalog, you'll have to release an updated FBC graph of the IIB catalog. For staging, this means you'll end upd having to add a new IIB catalog source to your cluster so that your
+new operator is available for consumption. In production however, this is not necessary as the release is published directly to the production index.
+
+Note, if you haven't yet released the operator in production, you'll need to follow this [documentation](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/releasing/preparing-for-release.md#publishing-a-fbc-graph) to request your operator to be added to the production index. It is not added by default.
+
+
+* Clone the orchestrator-fbc repository:
+
+```console
+git clone https://github.com/parodos-dev/orchestrator-fbc.git
+```
+
+* Update the graph.yaml in the OCP version following the FBC documentation to ensure that each each version published has an upgrade path. Check [this page](https://docs.openshift.com/container-platform/4.17/extensions/catalogs/fbc.html#olm-channel-schema_fbc) to understand the different options when updating the fragment.
+  The most common case is when updating the [z-stream version](https://github.com/parodos-dev/orchestrator-fbc/pull/92), in which case you will have to amend the original fragment (graph.yaml) and define the linkage between releases, so that the newest one is marked as a replacement to the previous one, and so on. So if we wanted to add the new release as `1.2.0-rc11` to the current graph.yaml, we'd be adding a value in the `entries:` section, and another pair for the `image` and `schema` with the pullspec of the bundle. Note that you should have the digest of the bundle image in `$bundlePullSpec`.
+
+```console
+---
+defaultChannel: alpha
+icon:
+  base64data: PD94bW....
+name: orchestrator-operator
+schema: olm.package
+---
+entries:
+- name: orchestrator-operator.v1.2.0-rc11
+  replaces: orchestrator-operator.v1.2.0-rc10
+- name: orchestrator-operator.v1.2.0-rc10
+  replaces: orchestrator-operator.v1.2.0-rc9
+- name: orchestrator-operator.v1.2.0-rc9
+name: alpha
+package: orchestrator-operator
+schema: olm.channel
+---
+image: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:e8196126d48692ab2f451ad5ef8033ffc14c89fd9b139615fe5a8a75166b1405
+schema: olm.bundle
+# orchestrator-helm-operator v.1.2.0-rc9
+---
+image: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:0f109419f233bf3a27e50ef9d1bc8f3bee5ce61b391014cbb52070a90606e08f
+schema: olm.bundle
+# orchestrator-helm-operator v.1.2.0-rc10
+---
+image: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:5ee318302c87a7ee36c3d620f9c01ac2288c5d59e63ae95fde47c0d172fa13ea
+schema: olm.bundle
+# orchestrator-helm-operator v.1.2.0-rc11
+```
+
+
+* Run the `generate-fbc.sh --render <OCP version>` command to generate the new catalog and then update the resulting catalog manifest to ensure that it references the staging repository for the controller. Review the changes and revert any reference to the `quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator` pullspec in the generated images, if any. This is a leftover from the first publishes of the catalog where the initial bundle was referencing this pullspec instead of staging or production.
+
+* Create a PR with the changes and merge it once it's green. Ensure that the on-push and ECP pipelines finish before proceeding. You'll need the snapshot generated from the ECP pipeline to release the FBC fragment to the index.
+
+* Follow these steps for each OCP version:
+
+  * Identify the snapshot that contains the PR you just merged:
+
+  ```console
+  componentName=fbc-v4-14
+  oc get snapshots --sort-by .metadata.creationTimestamp -l pac.test.appstudio.openshift.io/event-type=push,appstudio.openshift.io/application=$componentName -ojsonpath='{range .items[*]}{@.metadata.name}{"\t"}{@.status.conditions[?(@.type=="AppStudioTestSucceeded")].status}{"\t"}{@.metadata.annotations.pac\.test\.appstudio\.openshift\.io/sha-title}{"\n"}{end}'
+  ```
+
+  Example:
+
+  ```console
+  ...
+  ...
+  fbc-v4-14-5p7m9	True	Merge pull request #81 from jordigilh/release/1.2.0-rc6
+  fbc-v4-14-jv6f8	True	Merge pull request #83 from parodos-dev/konflux/references/main
+  fbc-v4-14-dhxqb	True	Merge pull request #82 from parodos-dev/konflux/component-updates/operator-bundle
+  fbc-v4-14-bdx8p	True	Merge pull request #85 from parodos-dev/konflux/component-updates/operator-bundle
+  fbc-v4-14-hftq5	True	Merge pull request #84 from parodos-dev/konflux/references/main
+  fbc-v4-14-g6b2z	True	Merge pull request #86 from jordigilh/release/1.2.0-rc9
+  fbc-v4-14-kttjb	True	Merge pull request #87 from jordigilh/release/ocp_4.14_rc9
+  fbc-v4-14-mcncx	True	Merge pull request #88 from jordigilh/release/orchestrator-rc9_ocp_prod
+  fbc-v4-14-hr78w	True	Merge pull request #90 from jordigilh/release/1.2.0-rc10
+  fbc-v4-14-6lhrt	True	Merge pull request #91 from jordigilh/4.15/fix_dockerfile_path
+  fbc-v4-14-rjwkj	True	Merge pull request #92 from jordigilh/release/stage/1.2.0-rc11
+  ```
+
+  The last one matches the source branch for the PR and it's Integration Tests are successful.
+
+  ```console
+  fbc-v4-14-rjwkj	True	Merge pull request #92 from jordigilh/release/stage/1.2.0-rc11
+  ```
+
+  * Create a new Release manifest for staging
+  ```console
+  snapshot=fbc-v4-14-rjwkj
+
+  releaseName=$(bash -c "oc create -f - <<EOF
+  apiVersion: appstudio.redhat.com/v1alpha1
+  kind: Release
+  metadata:
+    generateName: fbc-$componentName-
+    namespace: orchestrator-releng-tenant
+  spec:
+    releasePlan: $componentName-release-as-staging-fbc
+    snapshot: $snapshot
+  EOF" | awk '{print $1}')
+  ```
+
+  * Wait for the release to be validated:
+  ```console
+  while [ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Progressing" ];do sleep 5;done
+  [[ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Failed" ]] && echo Release failed: $(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].message}') || echo "Release successful"
+  ```
+  If the release fails, follow the [troubleshooting](#release-pipeline-failed) guide to find out the root cause.
+
+  * Extract the catalog IIB container image from the `extract-index-image` task. This task exposes the pullspec container image of the staging Red Hat IIB index with the additional FBC fragment of the operator.
+
+  ```console
+  pipelineRunName=$(oc get $releaseName -ojsonpath='{.status.processing.pipelineRun}{"\n"}' | awk -F'/' '{print $2}')
+  extractIndexTask=$(oc get taskrun -n rhtap-releng-tenant -l tekton.dev/pipelineRun=$pipelineRunName,tekton.dev/task=extract-index-image -oname)
+  extractIndexPod=$(oc get $extractIndexTask -n rhtap-releng-tenant -ojsonpath='{.status.podName}')
+  imagePullSpec=$(oc get pod -n rhtap-releng-tenant $extractIndexPod -ojsonpath='{.status.containerStatuses[?(@.name=="step-extract-index-image")].state.terminated.message}'| jq -r '.[] | select(.key == "indexImageResolved") | .value')
+  ```
+
+  * With the retrieved container image pullspec stored in `$imagePullSpec`, run the following command to generate a new `catalogsource` that references the staging catalog and deploy it in your cluster:
+
+  ```console
+  oc create -f - <<EOF
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: CatalogSource
+  metadata:
+    name: orchestrator-operator
+    namespace: openshift-marketplace
+  spec:
+    displayName: Orchestrator Operator
+    publisher: Red Hat
+    sourceType: grpc
+    grpcPodConfig:
+      securityContextConfig: restricted
+    image: $imagePullSpec
+    updateStrategy:
+      registryPoll:
+        interval: 10m
+  EOF
+  ```
+
+  * To deploy the operator, using the CLI, deploy a subscription that references the `orchestrator-operator` as the `source` or use the OLM UI in your OCP environment:
+
+  ```console
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: orchestrator-operator
+    namespace: openshift-operators
+  spec:
+    channel: alpha
+    installPlanApproval: Automatic
+    name: orchestrator-operator
+    source: orchestrator-operator
+    sourceNamespace: openshift-marketplace
+  ```
+
+
+## Production release
+
+### Releasing images to the production registry
+Releasing to production requires the images to be processed in staging first. Once that's successful, the process resolves in taking the staging snapshots from the helm-operator application and creating a new release using the production RPA. The FBC follows a similar step in that it needs a release aiming at the production RPA for each OCP release using the same snapshot. Let's start with the helm-operator application and then move on to the FBC release:
+
+* Identify the snapshot used in the stage release. List all the releases for staging and extract the snapshot used for that release. We will be using this snapshot for the production release. The next command will list all releases in staging that were successful sorted by `creationTimestamp` in ascending order (latest are the newest releases).
+
+```console
+oc get release --sort-by .metadata.creationTimestamp | grep helm-operator-staging |grep Succeeded
+```
+
+Example:
+```console
+helm-operator-staging-f4dnv   helm-operator-vslbm   helm-operator-staging              Succeeded        29h
+helm-operator-staging-f8dlm   helm-operator-vslbm   helm-operator-staging              Succeeded        28h
+```
+
+We'll use the snapshot `helm-operator-vslbm` for the production release, being the last successful release.
+
+```console
+snapshot=helm-operator-vslbm
+```
+* Create a new release manifest for Production:
+```console
+releaseName=$(bash -c "oc create -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  generateName: helm-operator-prod-
+  namespace: orchestrator-releng-tenant
+spec:
+  releasePlan: helm-operator-prod
+  snapshot: $snapshot
+EOF" | awk '{print $1}')
+```
+
+* Wait for the release to be validated:
+```console
+while [ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Progressing" ];do sleep 5;done
+[[ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Failed" ]] && echo Release failed: $(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].message}') || echo "Release successful"
+```
+
+If the release fails, follow the [troubleshooting](#release-pipeline-failed) guide to find out the root cause.
+
+* Validate that the container images are in the production registry by inspecting them with skopeo. The pullspec of the images are defined in the advisory manifest:
+
+```console
+advisoryURL=$(oc get $releaseName -n rhtap-releng-tenant -ojsonpath='{.status.artifacts.advisory.url}' | sed  's/blob/raw/')
+controllerPullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("controller-rhel9-operator$") ))| .[].containerImage')
+bundlePullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("orchestrator-operator-bundle$") ))| .[].containerImage')
+skopeo inspect docker://$controllerPullSpec >/dev/null && echo "Controller image found in $controllerPullSpec" || echo "Controller image not found in $controllerPullSpec"
+skopeo inspect docker://$bundlePullSpec >/dev/null && echo "Bundle image found in $bundlePullSpec" || echo "Controller image not found in $bundlePullSpec"
+```
+
+At this point, the container images have been pushed to the production registry. What's left is to update the FBC graph to aim for production registry, with no changes to the digest.
+
+
+### Releasing a new FBC index
+Releasing the fragment is a simple step to update the FBC graph manifest to point to the production registry and run the command to generate the catalog. The lastest commit in the repo should reflect the bundle's container image pullspec being the same as the one in the snapshot we retrieved from the stage build.
+
+```console
+---
+defaultChannel: alpha
+icon:
+  base64data: PD94bW....
+name: orchestrator-operator
+schema: olm.package
+---
+entries:
+- name: orchestrator-operator.v1.2.0-rc11
+  replaces: orchestrator-operator.v1.2.0-rc10
+- name: orchestrator-operator.v1.2.0-rc10
+  replaces: orchestrator-operator.v1.2.0-rc9
+- name: orchestrator-operator.v1.2.0-rc9
+name: alpha
+package: orchestrator-operator
+schema: olm.channel
+---
+image: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:e8196126d48692ab2f451ad5ef8033ffc14c89fd9b139615fe5a8a75166b1405
+schema: olm.bundle
+# orchestrator-helm-operator v.1.2.0-rc9
+---
+image: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:0f109419f233bf3a27e50ef9d1bc8f3bee5ce61b391014cbb52070a90606e08f
+schema: olm.bundle
+# orchestrator-helm-operator v.1.2.0-rc10
+---
+image: registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:5ee318302c87a7ee36c3d620f9c01ac2288c5d59e63ae95fde47c0d172fa13ea
+schema: olm.bundle
+# orchestrator-helm-operator v.1.2.0-rc11
+```
+
+* Run the `generate-fbc.sh --render <OCP version>` command to generate the new catalog and then update the resulting catalog manifest to ensure that it references the production repository for the controller. Review the changes and revert any reference to the `quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator` pullspec in the generated images, if any. This is a leftover from the first publishes of the catalog where the initial bundle was referencing this pullspec instead of staging or production.
+
+* Create a PR with the changes and merge it once it's green. Ensure that the on-push and ECP pipelines finish before proceeding. You'll need the snapshot generated from the ECP pipeline to add the FBC fragment to the production index.
+
+* Follow these steps for each OCP version:
+
+  * Identify the snapshot that contains the PR you just merged:
+
+  ```console
+  componentName=fbc-v4-14
+  oc get snapshots --sort-by .metadata.creationTimestamp -l pac.test.appstudio.openshift.io/event-type=push,appstudio.openshift.io/application=$componentName -ojsonpath='{range .items[*]}{@.metadata.name}{"\t"}{@.status.conditions[?(@.type=="AppStudioTestSucceeded")].status}{"\t"}{@.metadata.annotations.pac\.test\.appstudio\.openshift\.io/sha-title}{"\n"}{end}'
+  ```
+
+  Example:
+
+  ```console
+  ...
+  ...
+  fbc-v4-14-5p7m9	True	Merge pull request #81 from jordigilh/release/1.2.0-rc6
+  fbc-v4-14-jv6f8	True	Merge pull request #83 from parodos-dev/konflux/references/main
+  fbc-v4-14-dhxqb	True	Merge pull request #82 from parodos-dev/konflux/component-updates/operator-bundle
+  fbc-v4-14-bdx8p	True	Merge pull request #85 from parodos-dev/konflux/component-updates/operator-bundle
+  fbc-v4-14-hftq5	True	Merge pull request #84 from parodos-dev/konflux/references/main
+  fbc-v4-14-g6b2z	True	Merge pull request #86 from jordigilh/release/1.2.0-rc9
+  fbc-v4-14-kttjb	True	Merge pull request #87 from jordigilh/release/ocp_4.14_rc9
+  fbc-v4-14-mcncx	True	Merge pull request #88 from jordigilh/release/orchestrator-rc9_ocp_prod
+  fbc-v4-14-hr78w	True	Merge pull request #90 from jordigilh/release/1.2.0-rc10
+  fbc-v4-14-6lhrt	True	Merge pull request #91 from jordigilh/4.15/fix_dockerfile_path
+  fbc-v4-14-rjwkj	True	Merge pull request #92 from jordigilh/release/stage/1.2.0-rc11
+  fbc-v4-14-k3ksj	True	Merge pull request #93 from jordigilh/release/prod/1.2.0-rc11
+  ```
+
+  The last one matches the source branch for the PR and it's Integration Tests are successful.
+
+  ```console
+  fbc-v4-14-k3ksj	True	Merge pull request #93 from jordigilh/release/prod/1.2.0-rc11
+  ```
+
+  * Create a new Release manifest for staging
+  ```console
+  snapshot=fbc-v4-14-k3ksj
+
+  releaseName=$(bash -c "oc create -f - <<EOF
+  apiVersion: appstudio.redhat.com/v1alpha1
+  kind: Release
+  metadata:
+    generateName: fbc-$componentName-
+    namespace: orchestrator-releng-tenant
+  spec:
+    releasePlan: $componentName-release-as-production-fbc
+    snapshot: $snapshot
+  EOF" | awk '{print $1}')
+  ```
+
+  * Wait for the release to be validated:
+  ```console
+  while [ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Progressing" ];do sleep 5;done
+  [[ "$(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].reason}')" == "Failed" ]] && echo Release failed: $(oc get $releaseName -ojsonpath='{.status.conditions[?(@.type=="Processed")].message}') || echo "Release successful"
+  ```
+
+  If the release fails, follow the [troubleshooting](#release-pipeline-failed) guide to find out the root cause.
+
+  And that's all: the operator FBC's fragment has been added to the Red Hat Catalog. It will take some minutes for clusters to pull the new image and make the operator available.
+
+# Troubleshooting:
+
+## <a name="release-pipeline-failed"></a> Release pipeline failed
+
+If the release fails, you'll need to indentify which task failed and why. This gets a bit tricky as you'll have to jump over different objects until you get the information you seek. First, you'll need to get the pipelinerun from the status in the release. The following command will list the failed tasksrun objects for the pipelinerun
+
+```console
+pipelineRunName=$(oc get $releaseName -ojsonpath='{.status.processing.pipelineRun}{"\n"}' | awk -F'/' '{print $2}')
+oc get taskrun -n rhtap-releng-tenant -l tekton.dev/pipelineRun=$pipelineRunName -ojsonpath='{range .items[*]}{.status.conditions[?(@.type=="Succeeded")].status}{"\t"}{.metadata.name}{"\n"}{end}' | awk '{ if ($1=="False") print $2 }'
+```
+
+For each failed task, follow these steps to determine the problem:
+
+* Retrieve the pod. Remember to define `failedTask` with the name of the task from the previous command.
+```console
+taskRunPodName=$(oc get taskrun $failedTask -n rhtap-releng-tenant -ojsonpath='{.status.podName}')
+```
+
+* Retrieve the logs from the pod. Each task has different containers, so in some cases you'll have to dig in to find out which is the container that has the logs. For instance, the `verify-enteprise-contract` task has the logs in the `step-validate` container. The `rh-sign-image` has only one container, so there is no need to specify any.
+
+```console
+oc logs $taskRunPodName -n rhtap-releng-tenant -c step-validate
+```
+
+* Analyze the logs and determine the cause of the failure This is an example of a failed enterprise contract taskrun:
+
+```console
+Success: false
+Result: FAILURE
+Violations: 1, Warnings: 15, Successes: 196
+
+Components:
+- Name: orchestrator-operator-bundle
+  ImageRef: quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/orchestrator-operator-bundle@sha256:0...
+  Violations: 1, Warnings: 7, Successes: 98
+
+- Name: controller-rhel9-operator
+  ImageRef: quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller-rhel9-operator@sha256:f...
+  Violations: 0, Warnings: 8, Successes: 98
+
+Results:
+✕ [Violation] olm.allowed_registries
+  ImageRef: quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/orchestrator-operator-bundle@sha256:0...
+  Reason: The
+  "quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller-rhel9-operator@sha256:f...
+  CSV image reference is not from an allowed registry.
+  Title: Images referenced by OLM bundle are from allowed registries
+  Description: Each image referenced by the OLM bundle should match an entry in the list of prefixes defined by the rule data key
+  `allowed_registry_prefixes` in your policy configuration. To exclude this rule add
+  "olm.allowed_registries:quay.io/redhat-user-workloads/orchestrator-releng-tenant/helm-operator/controller-rhel9-operator" to the
+  `exclude` section of the policy configuration.
+  Solution: Use image from an allowed registry, or modify your xref:ec-cli:ROOT:configuration.adoc#_data_sources[policy
+  configuration] to include additional registry prefixes.
+```
+
+
+
+# Command tips:
+* Retrieve the components for a given application:
+```console
+oc get components -ojsonpath='{range .items[?(@.spec.application=="helm-operator")]}{.metadata.name}{"\n"}{end}}'
+```


### PR DESCRIPTION
Documentation for releasing the operator ~~to Staging~~ using Konflux. ~~Production release will come in a separated PR~~. I think this process can be scripted, but for now I will leave it as documentation since it can be helpful for better understanding how konflux works.

Update: I've included both staging and production and released 1.2.0-rc11 (which contains the same chart version as 1.2.0-rc10) for 4.13-4.15.

@masayag @rgolangh @pkliczewski PTAL.

