### PR TITLE
Allow traffic from knative-eventing and knative-serving

### DIFF
--- a/helm-charts/orchestrator/templates/network-policies.yaml
+++ b/helm-charts/orchestrator/templates/network-policies.yaml
@@ -18,4 +18,13 @@ spec:
             # Allow any other namespace the has workflows deployed because this is where
             # this namespace contains the sonataflow services
             rhdh.redhat.com/workflow-namespace: ""
+      - namespaceSelector:
+          matchLabels:
+            # Allow knative events to be delivered to workflows.
+            kubernetes.io/metadata.name: knative-eventing
+      - namespaceSelector:
+          matchLabels:
+            # Allow auxiliary knative function for workflow (such as m2k-save-transformation)
+            kubernetes.io/metadata.name: knative-serving
+
 {{- end }}


### PR DESCRIPTION
Workflows like move2kube deploy and use knative functions to achieve
the workflow tasks and working with functions means we need to allow the
traffic from knative-eventing and knative-serving namespace.

Traffic from knative-serving is needed when the function is deployed in
the same workflow namespace, because the way the function is triggered is
by the knative-serving components that send the event to the function.
So the traffic is knative-serving -> $workflows-ns (where the knative
function is deployed)

Traffic from knative-eventing is needed when functions or in the future
other events go through the knative broker and the trigger is sending
them to workflows. In the case of move2kube it is the
m2k-save-transformation function that sends an event, and that event
direction is knative-eventing -> $workflows-ns

https://issues.redhat.com/browse/FLPATH-1580

Signed-off-by: Roy Golan <rgolan@redhat.com>
