### PR TITLE
Change crd fqdn to rhdh.redhat.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.0-rc12
+VERSION ?= 1.2.0-rc13
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: parodos.dev
+domain: rhdh.redhat.com
 layout:
 - helm.sdk.operatorframework.io/v1
 plugins:
@@ -13,7 +13,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: parodos.dev
+  domain: rhdh.redhat.com
   group: orchestrator
   kind: Orchestrator
   version: v1alpha1

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "orchestrator.parodos.dev/v1alpha1",
+          "apiVersion": "rhdh.redhat.com/v1alpha1",
           "kind": "Orchestrator",
           "metadata": {
             "name": "orchestrator-sample"
@@ -41,7 +41,9 @@ metadata:
               "serviceNamespace": "sonataflow-infra"
             },
             "rhdhOperator": {
+              "enableGuestProvider": false,
               "enabled": true,
+              "isReleaseCandidate": false,
               "secretRef": {
                 "argocd": {
                   "password": "ARGOCD_PASSWORD",
@@ -60,34 +62,58 @@ metadata:
                   "clusterToken": "K8S_CLUSTER_TOKEN",
                   "clusterUrl": "K8S_CLUSTER_URL"
                 },
-                "name": "backstage-backend-auth-secret"
+                "name": "backstage-backend-auth-secret",
+                "notificationsEmail": {
+                  "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
+                  "password": "NOTIFICATIONS_EMAIL_PASSWORD",
+                  "username": "NOTIFICATIONS_EMAIL_USERNAME"
+                }
               },
               "subscription": {
-                "channel": "fast",
+                "channel": "fast-1.2",
                 "installPlanApproval": "Automatic",
                 "name": "rhdh",
-                "namespace": "rhdh-operator"
+                "namespace": "rhdh-operator",
+                "source": "redhat-operators",
+                "startingCSV": "",
+                "targetNamespace": "rhdh-operator"
               }
             },
             "rhdhPlugins": {
               "notifications": {
-                "integrity": "sha512-BQ7ujmrbv2MLelNGyleC4Z8fVVywYBMYZTwmRC534WCT38QHQ0cWJbebOgeIYszFA98STW4F5tdKbVot/2gWMg==",
-                "package": "plugin-notifications@1.2.5"
+                "integrity": "sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g==",
+                "package": "plugin-notifications-dynamic@0.2.0-rc.0-0"
               },
               "notificationsBackend": {
-                "integrity": "sha512-5zluThJwFVKX0Wlh4E15vDKUFGu/qJ0UsxHYWoISJ+ing1R38gskvN3kukylNTgOp8B78OmUglPfNlydcYEHvA==",
-                "package": "plugin-notifications-backend-dynamic@1.4.11"
+                "integrity": "sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ==",
+                "package": "plugin-notifications-backend-dynamic@0.2.0-rc.0-0"
               },
-              "npmRegistry": "",
+              "notificationsEmail": {
+                "enabled": false,
+                "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
+                "package": "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0",
+                "port": 587,
+                "replyTo": "",
+                "sender": ""
+              },
+              "npmRegistry": "https://npm.stage.registry.redhat.com",
               "orchestrator": {
-                "integrity": "sha512-qSXQ2O7/eLBEF186PzaRfzLfutFYUq9MdiiIZbHejz+KML9rVInPJkc1tine3R3JQVuw1QBIQ2vhPNbGbHXWZg==",
-                "package": "backstage-plugin-orchestrator@1.10.6"
+                "integrity": "sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ==",
+                "package": "backstage-plugin-orchestrator@1.1.0-rc.0-0"
               },
               "orchestratorBackend": {
-                "integrity": "sha512-wVZE7Dak10edxh1ZEckzYKrE13GrqhzSVelURhxjZcgXEHdGPWYUFHNMEpte7hzIBE85350Ka7fpy7C4BNPvEw==",
-                "package": "backstage-plugin-orchestrator-backend-dynamic@1.8.0"
+                "integrity": "sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw==",
+                "package": "backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0"
               },
-              "scope": "@janus-idp"
+              "scope": "@redhat",
+              "signals": {
+                "integrity": "sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg==",
+                "package": "plugin-signals-dynamic@0.0.5-rc.0-0"
+              },
+              "signalsBackend": {
+                "integrity": "sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg==",
+                "package": "plugin-signals-backend-dynamic@0.1.3-rc.0-0"
+              }
             },
             "serverlessOperator": {
               "enabled": true,
@@ -95,16 +121,20 @@ metadata:
                 "channel": "stable",
                 "installPlanApproval": "Automatic",
                 "name": "serverless-operator",
-                "namespace": "openshift-serverless"
+                "namespace": "openshift-serverless",
+                "sourceName": "redhat-operators"
               }
             },
             "sonataFlowOperator": {
               "enabled": true,
+              "isReleaseCandidate": false,
               "subscription": {
                 "channel": "alpha",
                 "installPlanApproval": "Automatic",
-                "name": "logicoperator-rhel8",
-                "namespace": "openshift-serverless-logic"
+                "name": "logic-operator-rhel8",
+                "namespace": "openshift-serverless-logic",
+                "sourceName": "redhat-operators",
+                "startingCSV": "logic-operator-rhel8.v1.33.0"
               }
             },
             "tekton": {
@@ -116,7 +146,7 @@ metadata:
     capabilities: Basic Install
     categories: Developer Tools
     console.openshift.io/disable-operand-delete: "true"
-    createdAt: "2024-07-11T19:22:12Z"
+    createdAt: "2024-09-12T17:54:38Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -140,7 +170,7 @@ metadata:
     operatorframework.io/arch.ppc64le: unsupported
     operatorframework.io/arch.s390x: unsupported
     operatorframework.io/suggested-namespace: orchestrator
-  name: orchestrator-operator.v1.2.0-rc5
+  name: orchestrator-operator.v1.2.0-rc12
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -152,7 +182,7 @@ spec:
         actions or external systems.
       displayName: Orchestrator
       kind: Orchestrator
-      name: orchestrators.orchestrator.parodos.dev
+      name: orchestrators.rhdh.redhat.com
       version: v1alpha1
   description: |
     Red Hat Developer Hub Orchestrator is a plugin that enables serverless asynchronous workflows to Backstage.
@@ -325,7 +355,19 @@ spec:
           - get
           - patch
         - apiGroups:
-          - orchestrator.parodos.dev
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - create
+          - delete
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - rhdh.redhat.com
           resources:
           - orchestrators
           - orchestrators/status
@@ -410,7 +452,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4@sha256:fcca9269424da38cfd216f4731de9fe5dea9f98e32c00da767b8e6e1ce9613cb
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:29201e85bd41642b72c7c0ce915e40aad90823d0efc3e7bbab9c351c92c74341
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -433,7 +475,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=orchestrator-operator
-                image: quay.io/orchestrator/orchestrator-operator:1.2.0-rc5
+                image: quay.io/orchestrator/orchestrator-operator:1.2.0-rc12
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -516,10 +558,10 @@ spec:
     url: https://github.com/parodos-dev/orchestrator-helm-operator
   maintainers:
   - email: jgil@redhat.com
-    name: Jordi Gil
+    name: Red Hat
   maturity: alpha
   minKubeVersion: 1.26.0
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.2.0-rc5
+  version: 1.2.0-rc12

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: orchestrators.orchestrator.parodos.dev
+  name: orchestrators.rhdh.redhat.com
 spec:
-  group: orchestrator.parodos.dev
+  group: rhdh.redhat.com
   names:
     kind: Orchestrator
     listKind: OrchestratorList
@@ -156,10 +156,15 @@ spec:
                 description: RHDH Operator contains the configuration fields for the
                   Red Hat Developer Hub operator
                 properties:
+                  catalogBranch:
+                    default: v1.2.x
+                    description: CatalogBranch captures the catalog branch value.
+                      Defaults to "v1.2.x".
+                    type: string
                   enableGuestProvider:
                     default: false
                     description: EnableGuestProvider captures whether to enable the
-                      guest provider in RHDH
+                      guest provider in RHDH. Defaults to false.
                     type: boolean
                   enabled:
                     default: true
@@ -268,15 +273,43 @@ spec:
                         default: backstage-backend-auth-secret
                         description: Name of the secret that contains the credentials
                           for the plugin to establish a communication channel with
-                          the Kubernetes API, ArgoCD and GitHub servers.
+                          the Kubernetes API, ArgoCD, GitHub servers and SMTP mail
+                          server.
                         type: string
+                      notificationsEmail:
+                        description: Notifications Email backstage plugin specific
+                          configuration fields that are injected to the backstage
+                          instance.
+                        properties:
+                          hostname:
+                            default: NOTIFICATIONS_EMAIL_HOSTNAME
+                            description: Key in the secret with name defined in the
+                              'name' field that contains the value of the hostname
+                              of the SMTP server for the notifications plugin. Defaults
+                              to 'NOTIFICATIONS_EMAIL_HOSTNAME', empty for not available.
+                            type: string
+                          password:
+                            default: NOTIFICATIONS_EMAIL_PASSWORD
+                            description: Key in the secret with name defined in the
+                              'name' field that contains the value of the password
+                              of the SMTP server for the notifications plugin. Defaults
+                              to 'NOTIFICATIONS_EMAIL_PASSWORD', empty for not available.
+                            type: string
+                          username:
+                            default: NOTIFICATIONS_EMAIL_USERNAME
+                            description: Key in the secret with name defined in the
+                              'name' field that contains the value of the username
+                              of the SMTP server for the notifications plugin. Defaults
+                              to 'NOTIFICATIONS_EMAIL_USERNAME', empty for not available.
+                            type: string
+                        type: object
                     type: object
                   subscription:
                     description: Subscription specifies the subscription attributes
                       to use to deploy the operator.
                     properties:
                       channel:
-                        default: fast
+                        default: fast-1.2
                         description: Channel defines the channel of the operator package
                           to subscribe to
                         type: string
@@ -305,8 +338,8 @@ spec:
                         type: string
                       targetNamespace:
                         default: rhdh-operator
-                        description: The target namespace for the backstage CR in which
-                          RHDH instance is created
+                        description: The target namespace for the backstage CR in
+                          which RHDH instance is created
                         type: string
                     type: object
                 type: object
@@ -317,11 +350,11 @@ spec:
                     description: Notification plugin information
                     properties:
                       integrity:
-                        default: sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g==
+                        default: sha512-3sKvF+sMzx1dPzSGHlbeePmUTrFKztSRcOQGsP60GHgEfg/g4NHQi2nZMlaYYG4+2/ChMl/CrA0vv481s5bgHg==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: plugin-notifications-dynamic@0.2.0-rc.0-0
+                        default: plugin-notifications-dynamic@1.2.0-rc.1
                         description: Package name
                         type: string
                     type: object
@@ -329,39 +362,61 @@ spec:
                     description: Notification backend plugin information
                     properties:
                       integrity:
-                        default: sha512-2Eqi1SWIy1vIWcR0hjSCfRP2w9z+qFdpKsB3dmbssv4Pg98AFj41LYlrTLscHri7am6cd4xe1fEb7gJGqbNQiQ==
+                        default: sha512-LgW8Jq5a0fxPymQoH99ssvwUz0mZLb3dmUx53LtImdT5+B/cKQ/VKa+iLDe7bMZepwqA0yJmjf/tDwKi8qzNqg==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: plugin-notifications-backend-dynamic@0.2.0-rc.0-0
+                        default: plugin-notifications-backend-dynamic@1.2.0-rc.1
                         description: Package name
                         type: string
                     type: object
-                  notifications_email:
+                  notificationsEmail:
                     description: Notification email plugin information
                     properties:
+                      enabled:
+                        default: false
+                        description: whether to install the notifications email plugin.
+                          requires setting of hostname and credentials in backstage
+                          secret to enable. See value backstage-backend-auth-secret.
+                          See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
+                        type: boolean
                       integrity:
-                        default: sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==
+                        default: sha512-S2+gNOoEyQMPATdfIIB4XvZPLGWqyCiAHsOgfgW3qxjM8paSYoxbhHtGP2m+1BePLSbm9PBjVv54xOWTPyL25A==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0
+                        default: plugin-notifications-backend-module-email-dynamic@1.2.0-rc.1
                         description: Package name
+                        type: string
+                      port:
+                        default: 587
+                        description: SMTP server port
+                        type: integer
+                      replyTo:
+                        default: ""
+                        description: Reply-to address
+                        type: string
+                      sender:
+                        default: ""
+                        description: The email sender address
                         type: string
                     type: object
                   npmRegistry:
                     default: https://npm.stage.registry.redhat.com
-                    description: NPM Registry
+                    description: NPM registry is defined already in the container,
+                      but sometimes the registry need to be modified to use different
+                      versions of the plugin, for example staging (https://npm.stage.registry.redhat.com)
+                      or development repositories
                     type: string
                   orchestrator:
                     description: Orchestrator plugin information
                     properties:
                       integrity:
-                        default: sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ==
+                        default: sha512-4C3ZeaGeJdrDWRlWGm1sxiZrfn5cIYynlIsKCcKq+aGpZKJABaKesuvGScBX++jmTbCUMDwPXZmWF20ZzSCuxg==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: backstage-plugin-orchestrator@1.1.0-rc.0-0
+                        default: backstage-plugin-orchestrator@1.2.0-rc.1
                         description: Package name
                         type: string
                     type: object
@@ -369,11 +424,11 @@ spec:
                     description: Orchestrator backend plugin information
                     properties:
                       integrity:
-                        default: sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw==
+                        default: sha512-uF7BVOTQEofTyKGvEW7ipPhbHCjsXw8wvSx1YyAQDSsVgq7l6FckUZN2jT0kXmiGqH2f7C7+xKIAoi/ETn3Kdw==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0
+                        default: backstage-plugin-orchestrator-backend-dynamic@1.2.0-rc.1
                         description: Package name
                         type: string
                     type: object
@@ -385,11 +440,11 @@ spec:
                     description: Signals plugin information
                     properties:
                       integrity:
-                        default: sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg==
+                        default: sha512-ESZJiXPL5hbE3w0oenBy/iY50V/QS5udqfdY0EggCLz7McsjYuBgz9zyowi87oxt8Sscu/Er9gquqi8gGAo4Dw==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: plugin-signals-dynamic@0.0.5-rc.0-0
+                        default: plugin-signals-dynamic@1.2.0-rc.1
                         description: Package name
                         type: string
                     type: object
@@ -397,11 +452,11 @@ spec:
                     description: Signals backend plugin information
                     properties:
                       integrity:
-                        default: sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg==
+                        default: sha512-yFSHfkvq9RTzeWTb+V0mMCxShrbHdad6AhNKZ0wU6ywbjw5N9CaedmD0eG+A7f7XEy3dLsmTxIlYbshdct4TiQ==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: plugin-signals-backend-dynamic@0.1.3-rc.0-0
+                        default: plugin-signals-backend-dynamic@1.2.0-rc.1
                         description: Package name
                         type: string
                     type: object
@@ -486,7 +541,7 @@ spec:
                         description: SourceName captures the name of the catalog source
                         type: string
                       startingCSV:
-                        default: ""
+                        default: logic-operator-rhel8.v1.33.0
                         description: The initial version of the operator
                         type: string
                     type: object

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: orchestrators.orchestrator.parodos.dev
+  name: orchestrators.rhdh.redhat.com
 spec:
-  group: orchestrator.parodos.dev
+  group: rhdh.redhat.com
   names:
     kind: Orchestrator
     listKind: OrchestratorList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,5 +2,5 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/orchestrator.parodos.dev_orchestrators.yaml
+- bases/rhdh.redhat.com_orchestrators.yaml
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-operator
-  newTag: 1.2.0-rc5
+  newTag: 1.2.0-rc12

--- a/config/manifests/bases/orchestrator-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/orchestrator-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ spec:
         actions or external systems.
       displayName: Orchestrator
       kind: Orchestrator
-      name: orchestrators.orchestrator.parodos.dev
+      name: orchestrators.rhdh.redhat.com
       version: v1alpha1
   description: |
     Red Hat Developer Hub Orchestrator is a plugin that enables serverless asynchronous workflows to Backstage.

--- a/config/rbac/orchestrator_editor_role.yaml
+++ b/config/rbac/orchestrator_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: orchestrator-editor-role
 rules:
 - apiGroups:
-  - orchestrator.parodos.dev
+  - rhdh.redhat.com
   resources:
   - orchestrators
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - orchestrator.parodos.dev
+  - rhdh.redhat.com
   resources:
   - orchestrators/status
   verbs:

--- a/config/rbac/orchestrator_viewer_role.yaml
+++ b/config/rbac/orchestrator_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: orchestrator-viewer-role
 rules:
 - apiGroups:
-  - orchestrator.parodos.dev
+  - rhdh.redhat.com
   resources:
   - orchestrators
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - orchestrator.parodos.dev
+  - rhdh.redhat.com
   resources:
   - orchestrators/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -165,10 +165,10 @@ rules:
   - patch
   - update
 ##
-## Rules for orchestrator.parodos.dev/v1alpha1, Kind: Orchestrator
+## Rules for orchestrator.rhdh.redhat.com/v1alpha1, Kind: Orchestrator
 ##
 - apiGroups:
-  - orchestrator.parodos.dev
+  - rhdh.redhat.com
   resources:
   - orchestrators
   - orchestrators/status

--- a/config/samples/_v1alpha1_orchestrator.yaml
+++ b/config/samples/_v1alpha1_orchestrator.yaml
@@ -1,4 +1,4 @@
-apiVersion: orchestrator.parodos.dev/v1alpha1
+apiVersion: rhdh.redhat.com/v1alpha1
 kind: Orchestrator
 metadata:
   name: orchestrator-sample

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples of your project ##
 resources:
-- orchestrator_v1alpha1_orchestrator.yaml
+- _v1alpha1_orchestrator.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
* Changes the API domain to `rhdh.redhat.com` to align with SKU
* Release 1.2.0-rc13

Note that this release deprecates the CRD for `orchestrators.parodos.dev` as the controller will no longer reconcile this API group.