### PR TITLE
[FLPATH-1682] Change api group reference in the watches.yaml file to use rhdh.redhat.com

### DIFF
--- a/watches.yaml
+++ b/watches.yaml
@@ -1,5 +1,5 @@
 # Use the 'create api' subcommand to add watches to this file.
-- group: orchestrator.parodos.dev
+- group: rhdh.redhat.com
   version: v1alpha1
   kind: Orchestrator
   chart: helm-charts/orchestrator


### PR DESCRIPTION
Fixes an issue while deploying the operator that caused it to fail due to invalid API group in the helm configuration (watches.yaml). Tested deploying this version in a cluster and creating a CR with success.