### PR TITLE
Fix apiVersion of sample _v1alpha1_orchestrator

### DIFF
--- a/config/samples/_v1alpha1_orchestrator.yaml
+++ b/config/samples/_v1alpha1_orchestrator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rhdh.redhat.com/v1alpha1
+apiVersion: orchestrator.parodos.dev/v1alpha1
 kind: Orchestrator
 metadata:
   name: orchestrator-sample


### PR DESCRIPTION
When following the [README](https://github.com/parodos-dev/orchestrator-helm-operator/blob/main/docs/main/README.md) on the section when we apply the sample CRD, I have an error:
```
$ oc apply -n orchestrator -f https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/refs/heads/main/config/samples/_v1alpha1_orchestrator.yaml
error: resource mapping not found for name: "orchestrator-sample" namespace: "" from "https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/refs/heads/main/config/samples/_v1alpha1_orchestrator.yaml": no matches for kind "Orchestrator" in version "rhdh.redhat.com/v1alpha1"
ensure CRDs are installed first
```

And 
```
oc get crd orchestrators.orchestrator.parodos.dev -o yaml | more
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    operatorframework.io/installed-alongside-b6788431c866bb6a: openshift-operators/orchestrator-operator.v1.2.0-rc11
  creationTimestamp: "2024-10-07T09:19:48Z"
  generation: 1
  labels:
    olm.managed: "true"
    operators.coreos.com/orchestrator-operator.openshift-operators: ""
  name: orchestrators.orchestrator.parodos.dev
  resourceVersion: "39717"
  uid: d3c6e3a3-6b97-4ad3-818d-287b51513ea9
spec:
  conversion:
    strategy: None
  group: orchestrator.parodos.dev
  names:
    kind: Orchestrator
    listKind: OrchestratorList
    plural: orchestrators
    singular: orchestrator
  scope: Namespaced
```

Seems the `apiVersion` is wrong, at least with `1.2.0-rc11 provided by Red Hat` 