### PR TITLE
Ensure only the bundle version field is updated when building with konflux

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /operator
 COPY . .
 RUN VERSION=$(grep "^VERSION ?="  Makefile | awk -F'= ' '{print $2}') && \
 	IMAGE_TAG_BASE=$(grep "^IMAGE_TAG_BASE ?=" Makefile | awk -F'= ' '{print $2}') && \
-	sed -i 's|version: .*|version: '${VERSION}'|g; s|name: orchestrator-operator.v.*|name: orchestrator-operator.v.'${VERSION}'|g; s|image: '${IMAGE_TAG_BASE}'.*|image: '$IMG'|g' bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+	sed -i 's|^\s\sversion: .*|  version: '${VERSION}'|; s|name: orchestrator-operator.v.*|name: orchestrator-operator.v.'${VERSION}'|g; s|image: '${IMAGE_TAG_BASE}'.*|image: '$IMG'|g' bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
 
 # Build bundle
 FROM scratch


### PR DESCRIPTION
Change the sed expression to ensure that only the bundle `version` field is updated to reflect the operator version, and not replace all instances of the `version` string found in the CSV, because it replaces the GKV field that defaults to`v1alpha1` with the bundle version:

```
  customresourcedefinitions:
    owned:
      displayName: Orchestrator
      kind: Orchestrator
      name: orchestrators.rhdh.redhat.com
      version: v1alpha1
```
to

```
  customresourcedefinitions:
    owned:
      displayName: Orchestrator
      kind: Orchestrator
      name: orchestrators.rhdh.redhat.com
      version: v1.2.1
```

 And then `opm` fails to render the catalog with this error message:
```
2024/10/16 12:32:05 render reference "quay.io/jordigilh/orchestrator-operator-bundle:2": error checking provided apis in bundle orchestrator-operator.v.1.2.1: couldn't find rhdh.redhat.com/1.2.1/Orchestrator (orchestrators) in bundle. found: map[rhdh.redhat.com/v1alpha1/Orchestrator (orchestrators):{}]
```