### PR TITLE
Change main reference to 1.2 in README.md links for 1.2

### DIFF
--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -16,7 +16,7 @@ You have two options for meeting this requirement:\
 
 ## For Software template
 1. **OpenShift Gitops (ArgoCD) and OpenShift Pipelines (Tekton)**\
-For using the Orchestrator's [software templates](https://github.com/parodos-dev/workflow-software-templates/tree/v1.2.x), OpenShift Gitops (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins)
+For using the Orchestrator's [software templates](https://github.com/parodos-dev/workflow-software-templates/tree/main), OpenShift Gitops (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins)
 
 # Installation steps
 
@@ -224,9 +224,9 @@ See more configuration options for the plugin [here](https://github.com/backstag
 ### Import Orchestrator's software templates
 To import the Orchestrator software templates into the catalog via the Backstage UI, follow the instructions outlined in this [document](https://backstage.io/docs/features/software-templates/adding-templates).
 Register new templates into the catalog from the
-- [Workflow resources (group and system)](https://github.com/parodos-dev/workflow-software-templates/blob/v1.2.x/entities/workflow-resources.yaml) (optional)
-- [Basic template](https://github.com/parodos-dev/workflow-software-templates/blob/v1.2.x/scaffolder-templates/basic-workflow/template.yaml)
-- [Complex template - workflow with custom Java code](https://github.com/parodos-dev/workflow-software-templates/blob/v1.2.x/scaffolder-templates/complex-assessment-workflow/template.yaml)
+- [Workflow resources (group and system)](https://github.com/parodos-dev/workflow-software-templates/blob/main/entities/workflow-resources.yaml) (optional)
+- [Basic template](https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/basic-workflow/template.yaml)
+- [Complex template - workflow with custom Java code](https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/complex-assessment-workflow/template.yaml)
 
 ## Upgrade plugin versions - WIP
 To perform an upgrade of the plugin versions, start by acquiring the new plugin version along with its associated integrity value.

--- a/docs/release-1.2/README.md
+++ b/docs/release-1.2/README.md
@@ -68,7 +68,7 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
 1.  Download the setup script from the github repository and run it to create the RHDH secret and label the GitOps namespaces:
 
     ```console
-    wget https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/main/hack/setup.sh -O /tmp/setup.sh && chmod u+x /tmp/setup.sh
+    wget https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/release-1.2/hack/setup.sh -O /tmp/setup.sh && chmod u+x /tmp/setup.sh
     ```
 
     Run the script:
@@ -131,7 +131,7 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
 1.  Run the following commands to determine when the installation is completed:
 
     ```console
-    wget https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/main/hack/wait_for_operator_installed.sh -O /tmp/wait_for_operator_installed.sh && chmod u+x /tmp/wait_for_operator_installed.sh && /tmp/wait_for_operator_installed.sh
+    wget https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/release-1.2/hack/wait_for_operator_installed.sh -O /tmp/wait_for_operator_installed.sh && chmod u+x /tmp/wait_for_operator_installed.sh && /tmp/wait_for_operator_installed.sh
     ```
 
     During the installation process, Kubernetes cronjobs are created by the operator to monitor the lifecycle of the CRs managed by the operator: RHDH operator, OpenShift Serverless operator and OpenShift Serverless Logic operator. When deleting one of the previously mentioned CRs, a job is triggered that ensures the CR is removed before the operator is.
@@ -140,9 +140,9 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
     > **Note:** that every minute on the clock a job is triggered to reconcile the CRs with the orchestrator resource values. These cronjobs are deleted when their respective features (e.g. `rhdhOperator.enabled=false`) are removed or when the orchestrator resource is removed. This is required because the CRs are not managed by helm due to the CRD dependency pre availability to the deployment of the CR.
 
 1. Apply the Orchestrator custom resource (CR) on the cluster to create an instance of RHDH and resources of OpenShift Serverless Operator and OpenShift Serverless Operator Logic.
-   Make any changes to the [CR](https://github.com/parodos-dev/orchestrator-helm-operator/blob/main/config/samples/_v1alpha1_orchestrator.yaml) before applying it, or test the default Orchestrator CR:
+   Make any changes to the [CR](https://github.com/parodos-dev/orchestrator-helm-operator/blob/release-1.2/config/samples/_v1alpha1_orchestrator.yaml) before applying it, or test the default Orchestrator CR:
     ```console
-    oc apply -n orchestrator -f https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/refs/heads/main/config/samples/_v1alpha1_orchestrator.yaml
+    oc apply -n orchestrator -f https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/refs/heads/release-1.2/config/samples/_v1alpha1_orchestrator.yaml
     ```
 
 ## Additional information
@@ -174,7 +174,7 @@ When deploying a workflow in a namespace different from where Sonataflow service
    Store the namespace value in SONATAFLOW_PLATFORM_NAMESPACE.
 
 4. **Set Up a Network Policy:**
-   Configure a network policy to allow traffic only between RHDH, Sonataflow services, and the workflows. The policy can be derived from [here](https://github.com/parodos-dev/orchestrator-helm-operator/blob/main/helm-charts/orchestrator/templates/network-policies.yaml)
+   Configure a network policy to allow traffic only between RHDH, Sonataflow services, and the workflows. The policy can be derived from [here](https://github.com/parodos-dev/orchestrator-helm-operator/blob/release-1.2/helm-charts/orchestrator/templates/network-policies.yaml)
 
    ```console
    oc create -f <<EOF


### PR DESCRIPTION
In the README for 1.2, there were links for scripts pointing to `main` instead of `release-1.2` branch, this PR fixes that