### PR TITLE
Update reference to serverless-workflow in tekton task to point to 1.3.x (latest)

### DIFF
--- a/helm-charts/orchestrator/templates/tekton-tasks.yaml
+++ b/helm-charts/orchestrator/templates/tekton-tasks.yaml
@@ -195,7 +195,7 @@ spec:
 
         ls flat/$(params.workflowId)
         
-        curl -L https://raw.githubusercontent.com/parodos-dev/serverless-workflows/v1.2.x/pipeline/workflow-builder.Dockerfile -o flat/workflow-builder.Dockerfile
+        curl -L https://raw.githubusercontent.com/parodos-dev/serverless-workflows/v1.3.x/pipeline/workflow-builder.Dockerfile -o flat/workflow-builder.Dockerfile
 ---
 apiVersion: tekton.dev/v1
 kind: Task


### PR DESCRIPTION
Update reference to serverless-workflow in tekton task to point to 1.3.x (latest)

Part of closing https://issues.redhat.com/browse/FLPATH-1686 with https://github.com/parodos-dev/workflow-software-templates/pull/83