### PR TITLE
Enable gh dynamic plugin

### DIFF
--- a/helm-charts/orchestrator/templates/rhdh-operator.yaml
+++ b/helm-charts/orchestrator/templates/rhdh-operator.yaml
@@ -230,6 +230,8 @@ data:
       - disabled: false
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signalsBackend.package }}"
         integrity: {{ .Values.rhdhPlugins.signalsBackend.integrity }}
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
   {{- if and .Values.rhdhPlugins.notificationsEmail.enabled
         ( and (.Values.rhdhOperator.secretRef.notificationsEmail.hostname) (dig "data" .Values.rhdhOperator.secretRef.notificationsEmail.hostname "" $secret ) )
   }}


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1791

Starting RHDH 1.3 some plugins are disabled by default, we were using the gh plugin so this change broke our workflow template. See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.3/html-single/release_notes/index#removed-functionality-rhidp-3187

This PR explicitly enables the gh plugin.