### PR TITLE
Update values.yaml to point to the 1.3.0-rc plugins

### DIFF
--- a/helm-charts/orchestrator/values.yaml
+++ b/helm-charts/orchestrator/values.yaml
@@ -56,27 +56,27 @@ rhdhPlugins: # RHDH plugins required for the Orchestrator
   npmRegistry: "https://npm.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
   scope: "@redhat"
   orchestrator:
-    package: "backstage-plugin-orchestrator@1.2.0"
-    integrity: sha512-FhM13wVXjjF39syowc4RnMC/gKm4TRlmh8lBrMwPXAw1VzgIADI8H6WVEs837poVX/tYSqj2WhehwzFqU6PuhA==
+    package: "backstage-plugin-orchestrator@1.3.0-rc.0"
+    integrity: sha512-rg+VX81ILTXhfyZqyff0rSmoeEse47ICjKcdavxvfKiG+Rd4uxo80P6o5ca2ZLzsJhYPiKk9Jl3HPtcmLCGzPg==
   orchestratorBackend:
-    package: "backstage-plugin-orchestrator-backend-dynamic@1.2.0"
+    package: "backstage-plugin-orchestrator-backend-dynamic@1.3.0-rc.0"
     integrity: sha512-lyw7IHuXsakTa5Pok8S2GK0imqrmXe3z+TcL7eB2sJYFqQPkCP5la1vqteL9/1EaI5eI6nKZ60WVRkPEldKBTg==
   notifications:
-    package: "plugin-notifications-dynamic@1.2.0"
-    integrity: sha512-1mhUl14v+x0Ta1o8Sp4KBa02izGXHd+wsiCVsDP/th6yWDFJsfSMf/DyMIn1Uhat1rQgVFRUMg8QgrvbgZCR/w==
+    package: "plugin-notifications-dynamic@1.3.0-rc.3"
+    integrity: sha512-zqwK318o+Lc16pV5wvN6IWMLFqImOWr0xbsGBI69YNVGpXA6AOccXInGbn1RA1QKXfV5sNo8xc5N0WIIgx43Iw==
   notificationsBackend:
-    package: "plugin-notifications-backend-dynamic@1.2.0"
-    integrity: sha512-pCFB/jZIG/Ip1wp67G0ZDJPp63E+aw66TX1rPiuSAbGSn+Mcnl8g+XlHLOMMTz+NPloHwj2/Tp4fSf59w/IOSw==
+    package: "plugin-notifications-backend-dynamic@1.3.0-rc.3"
+    integrity: sha512-2qai8t66dyHEIaPFjdJ9M5nPh53vkH5O7Keed/lFNH0TbPoxamql9V0tdOwdx5Mb7bJwj9N1ulin/mCNniFuTA==
   signals:
-    package: "plugin-signals-dynamic@1.2.0"
-    integrity: sha512-5tbZyRob0JDdrI97HXb7JqFIzNho1l7JuIkob66J+ZMAPCit+pjN1CUuPbpcglKyyIzULxq63jMBWONxcqNSXw==
+    package: "plugin-signals-dynamic@1.3.0-rc.3"
+    integrity: sha512-WRUi5xpJDD5Jd2p+juCIpsXCnXfHLoSwPZ/N7a7ZnqarfajTkL8qOglhIJh+lVTbe65S8v1rtQLGj9bTCXuPlA==
   signalsBackend:
-    package: "plugin-signals-backend-dynamic@1.2.0"
-    integrity: sha512-DIISzxtjeJ4a9mX3TLcuGcavRHbCtQ5b52wHn+9+uENUL2IDbFoqmB4/9BQASaKIUSFkRKLYpc5doIkrnTVyrA==
+    package: "plugin-signals-backend-dynamic@1.3.0-rc.3"
+    integrity: sha512-FgmPouKc2FuHSMfmkdXCVx0/1kPlT6OVbRUNFzOJGSjZAj0nvxSg+W3pt15dSOC5Fe5j2FLSuevCx34YVA+VzQ==
   notificationsEmail:
     enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
-    package: "plugin-notifications-backend-module-email-dynamic@1.2.0"
-    integrity: sha512-dtmliahV5+xtqvwdxP2jvyzd5oXTbv6lvS3c9nR8suqxTullxxj0GFg1uU2SQ2uKBQWhOz8YhSmrRwxxLa9Zqg==
+    package: "plugin-notifications-backend-module-email-dynamic@1.3.0-rc.3"
+    integrity: sha512-uIGPDdSha9H1kWwofYJXg/GgrGZuF9WZTXgRb8YtN4iKAAZ9FLAD9BuLobUKYXbzO6jGaNzIw82kTJa1VhvEzg==
     port: 587 # SMTP server port
     sender: "" # the email sender address
     replyTo: "" # reply-to address


### PR DESCRIPTION
Fixes an issue where the values not defined in the CR were taken by default from the `values.yaml` file, instead of being populated by the CRD spec's default values.

@chadcrum FYI