### PR TITLE
Update Dockerfile to use new helm-operator base image to fix latest CVE issues in ubi8-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/orchestrator/helm-operator:v1.35.0-cve-fixes
+FROM quay.io/orchestrator/helm-operator:v1.35.0-cve-fixes-12NOV24
 
 
 LABEL com.redhat.component="RHDH Orchestrator Helm Operator"


### PR DESCRIPTION
@jenniferubah FYI