### PR TITLE
Update refereneces in docs to helm-based operator repository

### DIFF
--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -61,7 +61,7 @@ To install the OpenShift GitOps Operator with custom configuration:
 
     ```bash
     oc new-project orchestrator-gitops
-    oc apply -f https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-chart/main/docs/gitops/resources/argocd-example.yaml
+    oc apply -f https://raw.githubusercontent.com/parodos-dev/orchestrator-helm-operator/main/docs/gitops/resources/argocd-example.yaml
     ```
 
     Alternatively, if creating a default ArgoCD instance, ensure to exclude Tekton resources from its specification:

--- a/docs/main/README.md
+++ b/docs/main/README.md
@@ -57,7 +57,7 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
    - **If you do not have a PostgreSQL instance in your cluster** \
    you can deploy the PostgreSQL reference implementation by following the steps here.
    - **If you already have PostgreSQL running in your cluster** \
-   ensure that the default settings in the [PostgreSQL values](https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/postgresql/values.yaml) file match those provided in the [Orchestrator values](https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/charts/orchestrator/values.yaml) file.
+   ensure that the default settings in the [PostgreSQL values](https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/postgresql/values.yaml) file match those provided in the [Orchestrator values](https://github.com/parodos-dev/orchestrator-helm-operator/blob/main/helm-charts/orchestrator/values.yaml) file.
 1. Install Orchestrator operator
    1. Go to OperatorHub in your OpenShift Console.
    1. Search for and install the Orchestrator Operator.

--- a/docs/postgresql/README.md
+++ b/docs/postgresql/README.md
@@ -19,7 +19,7 @@ helm install sonataflow-psql bitnami/postgresql --version 12.x.x -f ./values.yam
 ```
 
 Note: the default settings provided in [PostgreSQL values](https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/postgresql/values.yaml) match the defaults provided in the
-[Orchestrator values](https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/charts/orchestrator/values.yaml).
+[Orchestrator values](https://github.com/parodos-dev/orchestrator-helm-operator/blob/main/helm-charts/orchestrator/values.yaml).
 Any changes to the first configuration must also be reported in the latter.
 
 For OpenShift-related configuration in the chart visit [here](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/README.md#differences-between-bitnami-postgresql-image-and-docker-official-image).


### PR DESCRIPTION
Few places in the code referred to the previous helm chart repository.

Fixes #355

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED