### PR TITLE
Backport sample for plugin version - update sample plugin version

### DIFF
--- a/config/samples/_v1alpha1_orchestrator.yaml
+++ b/config/samples/_v1alpha1_orchestrator.yaml
@@ -56,27 +56,27 @@ spec:
     npmRegistry: "https://npm.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
     scope: "@redhat"
     orchestrator:
-      package: "backstage-plugin-orchestrator@1.1.0-rc.0-0"
-      integrity: sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ==
+      package: "backstage-plugin-orchestrator@1.2.0"
+      integrity: sha512-FhM13wVXjjF39syowc4RnMC/gKm4TRlmh8lBrMwPXAw1VzgIADI8H6WVEs837poVX/tYSqj2WhehwzFqU6PuhA==
     orchestratorBackend:
-      package: "backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0"
-      integrity: sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw==
+      package: "backstage-plugin-orchestrator-backend-dynamic@1.2.0"
+      integrity: sha512-lyw7IHuXsakTa5Pok8S2GK0imqrmXe3z+TcL7eB2sJYFqQPkCP5la1vqteL9/1EaI5eI6nKZ60WVRkPEldKBTg==
     notifications:
-      package: "plugin-notifications-dynamic@0.2.0-rc.0-0"
-      integrity: sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g==
+      package: "plugin-notifications-dynamic@1.2.0"
+      integrity: sha512-1mhUl14v+x0Ta1o8Sp4KBa02izGXHd+wsiCVsDP/th6yWDFJsfSMf/DyMIn1Uhat1rQgVFRUMg8QgrvbgZCR/w==
     notificationsBackend:
-      package: "plugin-notifications-backend-dynamic@0.2.0-rc.0-0"
-      integrity: sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ==
+      package: "plugin-notifications-backend-dynamic@1.2.0"
+      integrity: sha512-pCFB/jZIG/Ip1wp67G0ZDJPp63E+aw66TX1rPiuSAbGSn+Mcnl8g+XlHLOMMTz+NPloHwj2/Tp4fSf59w/IOSw==
     signals:
-      package: "plugin-signals-dynamic@0.0.5-rc.0-0"
-      integrity: sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg==
+      package: "plugin-signals-dynamic@1.2.0"
+      integrity: sha512-5tbZyRob0JDdrI97HXb7JqFIzNho1l7JuIkob66J+ZMAPCit+pjN1CUuPbpcglKyyIzULxq63jMBWONxcqNSXw==
     signalsBackend:
-      package: "plugin-signals-backend-dynamic@0.1.3-rc.0-0"
-      integrity: sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg==
+      package: "plugin-signals-backend-dynamic@1.2.0"
+      integrity: sha512-DIISzxtjeJ4a9mX3TLcuGcavRHbCtQ5b52wHn+9+uENUL2IDbFoqmB4/9BQASaKIUSFkRKLYpc5doIkrnTVyrA==
     notificationsEmail:
       enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
-      package: "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"
-      integrity: sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==
+      package: "plugin-notifications-backend-module-email-dynamic@1.2.0"
+      integrity: sha512-dtmliahV5+xtqvwdxP2jvyzd5oXTbv6lvS3c9nR8suqxTullxxj0GFg1uU2SQ2uKBQWhOz8YhSmrRwxxLa9Zqg==
       port: 587 # SMTP server port
       sender: "" # the email sender address
       replyTo: "" # reply-to address


### PR DESCRIPTION
The `release-1.2` branch does not contain the corrects plugins versions, @masayag fixed that in https://github.com/parodos-dev/orchestrator-helm-operator/commit/8ecf624cba44ce0849cfa59ceafc2db2dd5559d4#diff-80c52a31fc60fcf8e95cb22f03d3d5cefd3b745221386c37d3166bd0b93caa3eR56 but it was not backported to the branch

This PR does it