### PR TITLE
Fixed the link to the Orchestrator documentation

### DIFF
--- a/docs/release-1.3/README.md
+++ b/docs/release-1.3/README.md
@@ -1,6 +1,6 @@
 # Orchestrator Documentation
 
-For comprehensive documentation on the Orchestrator, please visit [https://www.parodos.dev](https://www.parodos.dev).
+For comprehensive documentation on the Orchestrator, please visit [https://www.rhdhorchestrator.io/main/docs/](https://www.rhdhorchestrator.io/main/docs/).
 
 ## Installing the Orchestrator Helm Operator
 

--- a/docs/release-1.3/README.md
+++ b/docs/release-1.3/README.md
@@ -1,6 +1,6 @@
 # Orchestrator Documentation
 
-For comprehensive documentation on the Orchestrator, please visit [https://www.rhdhorchestrator.io/main/docs/](https://www.rhdhorchestrator.io/main/docs/).
+For comprehensive documentation on the Orchestrator, please visit [https://www.rhdhorchestrator.io](https://www.rhdhorchestrator.io).
 
 ## Installing the Orchestrator Helm Operator
 


### PR DESCRIPTION
Replaced the references to https://www.parodos.dev in the README.md with https://www.rhdhorchestrator.io/main/docs/