### PR TITLE
FLPATH-1856 Enabling monitoring by default in Helm Based Orchestrator operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.35.0
+OPERATOR_SDK_VERSION ?= v1.37.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -21,6 +21,9 @@ metadata:
             "orchestrator": {
               "namespace": "sonataflow-infra",
               "sonataflowPlatform": {
+                "monitoring": {
+                  "enabled": true
+                },
                 "resources": {
                   "limits": {
                     "cpu": "500m",
@@ -131,7 +134,7 @@ metadata:
     capabilities: Basic Install
     categories: Developer Tools
     console.openshift.io/disable-operand-delete: "true"
-    createdAt: "2024-12-19T16:28:07Z"
+    createdAt: "2024-12-20T00:49:45Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -155,16 +158,16 @@ metadata:
     operatorframework.io/arch.ppc64le: unsupported
     operatorframework.io/arch.s390x: unsupported
     operatorframework.io/suggested-namespace: orchestrator
-  name: orchestrator-operator.v1.3.0
+  name: orchestrator-operator.v1.4.0-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: RHDH Orchestrator introduces serverless asynchronous workflows to Backstage,
-        with a focus on facilitating the transition of applications to the cloud,
-        onboarding developers, and enabling users to create workflows for backstage
-        actions or external systems.
+    - description: RHDH Orchestrator introduces serverless asynchronous workflows
+        to Backstage, with a focus on facilitating the transition of applications
+        to the cloud, onboarding developers, and enabling users to create workflows
+        for backstage actions or external systems.
       displayName: Orchestrator
       kind: Orchestrator
       name: orchestrators.rhdh.redhat.com
@@ -477,7 +480,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=orchestrator-operator
-                image: quay.io/orchestrator/orchestrator-operator:1.3.0
+                image: quay.io/orchestrator/orchestrator-operator:1.4.0-rc1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -566,4 +569,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.3.0
+  version: 1.4.0-rc1

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -88,6 +88,15 @@ spec:
                           Job Service container image to be used instead of the provided
                           one by SonataFlow
                         type: string
+                      monitoring:
+                        description: Contains the monitoring configuration fields
+                        properties:
+                          enabled:
+                            default: true
+                            description: Enabled determines whether monitoring should
+                              be enabled. Defaults to true.
+                            type: boolean
+                        type: object
                       resources:
                         description: Resources contains the requests and limit of
                           CPU and memory resources for the pod instance

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -362,6 +362,14 @@ spec:
                   sonataflowPlatform:
                     description: SonataflowPlatform contains the pod resource configuration to be used for the data index and job services
                     properties:
+                      monitoring:
+                        description: Contains the monitoring configuration fields
+                        properties:
+                          enabled:
+                            description: Enabled determines whether monitoring should be enabled. Defaults to true.
+                            default: true
+                            type: boolean
+                        type: object
                       resources:
                         description: Resources contains the requests and limit of CPU and memory resources for the pod instance
                         type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-operator
-  newTag: 1.3.0
+  newTag: 1.4.0-rc1

--- a/config/manifests/bases/orchestrator-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/orchestrator-operator.clusterserviceversion.yaml
@@ -33,10 +33,10 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: RHDH Orchestrator introduces serverless asynchronous workflows to Backstage,
-        with a focus on facilitating the transition of applications to the cloud,
-        onboarding developers, and enabling users to create workflows for backstage
-        actions or external systems.
+    - description: RHDH Orchestrator introduces serverless asynchronous workflows
+        to Backstage, with a focus on facilitating the transition of applications
+        to the cloud, onboarding developers, and enabling users to create workflows
+        for backstage actions or external systems.
       displayName: Orchestrator
       kind: Orchestrator
       name: orchestrators.rhdh.redhat.com

--- a/config/samples/_v1alpha2_orchestrator.yaml
+++ b/config/samples/_v1alpha2_orchestrator.yaml
@@ -77,6 +77,8 @@ spec:
   orchestrator:
     namespace: "sonataflow-infra" # Namespace where sonataflow's workflows run. The value is captured when running the setup.sh script and stored as a label in the selected namespace. User can override the value by populating this field. Defaults to `sonataflow-infra`.
     sonataflowPlatform:
+      monitoring:
+        enabled: true
       resources:
         requests:
           memory: "64Mi"

--- a/helm-charts/orchestrator/templates/sonataflows.yaml
+++ b/helm-charts/orchestrator/templates/sonataflows.yaml
@@ -23,6 +23,8 @@ metadata:
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name}}
 spec:
+  monitoring:
+    enabled: {{ .Values.orchestrator.sonataflowPlatform.monitoring.enabled }}
   build:
     template:
       resources:

--- a/helm-charts/orchestrator/values.schema.json
+++ b/helm-charts/orchestrator/values.schema.json
@@ -896,9 +896,31 @@
                     "default": {},
                     "title": "The sonataflowPlatform Schema",
                     "required": [
+                        "monitoring",
                         "resources"
                     ],
                     "properties": {
+                        "monitoring": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The monitoring Schema",
+                            "required": [
+                                "enabled"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        false
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": false
+                            }]
+                        },
                         "resources": {
                             "type": "object",
                             "default": {},
@@ -1181,6 +1203,9 @@
         "orchestrator": {
             "namespace": "sonataflow-infra",
             "sonataflowPlatform": {
+                "monitoring": {
+                    "enabled": false
+                },
                 "resources": {
                     "requests": {
                         "memory": "64Mi",

--- a/helm-charts/orchestrator/values.yaml
+++ b/helm-charts/orchestrator/values.yaml
@@ -79,6 +79,8 @@ postgres:
 orchestrator:
   namespace: "sonataflow-infra" # Namespace where sonataflow's workflows run. The value is captured when running the setup.sh script and stored as a label in the selected namespace. User can override the value by populating this field. Defaults to `sonataflow-infra`.
   sonataflowPlatform:
+    monitoring:
+      enabled: true
     resources:
       requests:
         memory: "64Mi"


### PR DESCRIPTION
This PR updates the helm based Orchestrator Operator so that the SonataFlowPlatform CR is created with monitoring enabled by default. Users will be able to disable it by setting it to `false`.
```
  orchestrator:
    sonataflowPlatform:
      monitoring:
        enabled: true
```
Tested in RHPDS successfully with the local build of SonataFlow Operator from main branch.