### PR TITLE
Update tekton task to not use deprecated clusterTask and add support matrix for pipeline operator

### DIFF
--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -40,6 +40,17 @@ You can use the Janus IDP Demo repository to install the `Red Hat OpenShift Pipe
 
 The OpenShift Pipelines Operator can be installed directly from the OperatorHub. Select the operator from the list and install it without any special configuration.
 
+Make sure you install an OpenShift Pipelines Operator's version compatible with your Orchestrator Operator's version:
+
+| OpenShift Pipelines Operator version          |  Orchestrator Operator Version |
+|-----------------------------------------------|--------------------------------|
+| 4.13                                          |1.3.x                           |
+| 4.14                                          |1.3.x                           |
+| 4.15                                          |1.3.x                           |
+| 4.16                                          |1.3.x                           |
+| 4.17                                          |1.4.x                           |
+
+
 ### Install OpenShift GitOps Operator
 
 To install the OpenShift GitOps Operator with custom configuration:

--- a/helm-charts/orchestrator/templates/_helpers.tpl
+++ b/helm-charts/orchestrator/templates/_helpers.tpl
@@ -138,3 +138,12 @@
   {{- end -}}
   {{- $versionString -}}
 {{- end -}}
+
+{{- define "get-tekton-version" -}}
+        {{- $pipelinesSubs := lookup "operators.coreos.com/v1alpha1" "Subscription" "openshift-operators" "openshift-pipelines-operator-rh" -}}
+        {{- $pipelineInstalledVersion := $pipelinesSubs.status.installedCSV}}
+        {{- $pipelineVersion := substr 33 ( len $pipelineInstalledVersion) $pipelineInstalledVersion}}
+        {{- $pipelineVersion = semver $pipelineVersion }}
+        {{- $pipelineVersionString := printf "%d.%d" $pipelineVersion.Major $pipelineVersion.Minor -}}
+        {{- $pipelineVersionString -}}
+{{- end -}}

--- a/helm-charts/orchestrator/templates/tekton-pipeline.yaml
+++ b/helm-charts/orchestrator/templates/tekton-pipeline.yaml
@@ -1,5 +1,6 @@
 {{- if eq "true" (include "install-tekton-pipeline" .) }}
   {{- $gitopsNamespace := include "get-argocd-namespace" . }}
+  {{- $version = include "get-tekton-version" . -}}
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
@@ -115,8 +116,19 @@ spec:
     - name: build-and-push-image
       runAfter: ["flatten-workflow"]
       taskRef:
+{{- if (semverCompare ">=1.17" $version) -}}
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: buildah
+        - name: namespace
+          value: openshift-pipelines
+{{- else }}
         name: buildah
         kind: ClusterTask
+{{- end }}
       workspaces:
         - name: source
           workspace: workflow-source
@@ -130,7 +142,7 @@ spec:
         - name: CONTEXT
           value: flat/$(params.workflowId)
         - name: BUILD_EXTRA_ARGS
-          value: '--authfile=/workspace/dockerconfig/.dockerconfigjson --ulimit nofile=4096:4096 --build-arg WF_RESOURCES="." '
+          value: '--authfile=/workspace/dockerconfig/.dockerconfigjson --ulimit nofile=4096:4096 --build-arg WF_RESOURCES=. '
     - name: push-workflow-gitops
       runAfter: ["build-gitops", "build-and-push-image"]
       taskRef:


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1951

Update tekton task to not use deprecated clusterTask and add support matrix for pipeline operator