### PR TITLE
CRD Version v1alpha2

### DIFF
--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "rhdh.redhat.com/v1alpha1",
+          "apiVersion": "rhdh.redhat.com/v1alpha2",
           "kind": "Orchestrator",
           "metadata": {
             "name": "orchestrator-sample"
@@ -83,18 +83,8 @@ metadata:
               }
             },
             "rhdhPlugins": {
-              "notifications": {
-                "integrity": "sha512-iYLgIy0YdP/CdTLol07Fncmo9n0J8PdIZseiwAyUt9RFJzKIXmoi2CpQLPKMx36lEgPYUlT0rFO81Ie2CSis4Q==",
-                "package": "plugin-notifications-dynamic@1.3.0"
-              },
-              "notificationsBackend": {
-                "integrity": "sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==",
-                "package": "plugin-notifications-backend-dynamic@1.3.0"
-              },
               "notificationsEmail": {
                 "enabled": false,
-                "integrity": "sha512-sm7yRoO6Nkk3B7+AWKb10maIrb2YBNSiqQaWmFDVg2G9cbDoWr9wigqqeQ32+b6o2FenfNWg8xKY6PPyZGh8BA==",
-                "package": "plugin-notifications-backend-module-email-dynamic@1.3.0",
                 "port": 587,
                 "replyTo": "",
                 "sender": ""
@@ -109,14 +99,6 @@ metadata:
                 "package": "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
               },
               "scope": "@redhat",
-              "signals": {
-                "integrity": "sha512-+E8XeTXcG5oy+aNImGj/MY0dvEkP7XAsu4xuZjmAqOHyVfiIi0jnP/QDz8XMbD1IjCimbr/DMUZdjmzQiD0hSQ==",
-                "package": "plugin-signals-dynamic@1.3.0"
-              },
-              "signalsBackend": {
-                "integrity": "sha512-5Bl6C+idPXtquQxMZW+bjRMcOfFYcKxcGZZFv2ITkPVeY2zzxQnAz3vYHnbvKRSwlQxjIyRXY6YgITGHXWT0nw==",
-                "package": "plugin-signals-backend-dynamic@1.3.0"
-              }
             },
             "serverlessOperator": {
               "enabled": true,
@@ -186,7 +168,7 @@ spec:
       displayName: Orchestrator
       kind: Orchestrator
       name: orchestrators.rhdh.redhat.com
-      version: v1alpha1
+      version: v1alpha2
   description: |
     Red Hat Developer Hub Orchestrator is a plugin that enables serverless asynchronous workflows to Backstage.
 

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -98,7 +98,7 @@ metadata:
                 "integrity": "sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==",
                 "package": "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
               },
-              "scope": "@redhat",
+              "scope": "@redhat"
             },
             "serverlessOperator": {
               "enabled": true,

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -19,7 +19,7 @@ spec:
     - jsonPath: .status.conditions[-1:].reason
       name: Reason
       type: string
-    name: v1alpha1
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: Orchestrator is the Schema for the orchestrators API
@@ -369,30 +369,6 @@ spec:
               rhdhPlugins:
                 description: Backstage plugins
                 properties:
-                  notifications:
-                    description: Notification plugin information
-                    properties:
-                      integrity:
-                        default: sha512-iYLgIy0YdP/CdTLol07Fncmo9n0J8PdIZseiwAyUt9RFJzKIXmoi2CpQLPKMx36lEgPYUlT0rFO81Ie2CSis4Q==
-                        description: Package SHA integrity
-                        type: string
-                      package:
-                        default: plugin-notifications-dynamic@1.3.0
-                        description: Package name
-                        type: string
-                    type: object
-                  notificationsBackend:
-                    description: Notification backend plugin information
-                    properties:
-                      integrity:
-                        default: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==
-                        description: Package SHA integrity
-                        type: string
-                      package:
-                        default: plugin-notifications-backend-dynamic@1.3.0
-                        description: Package name
-                        type: string
-                    type: object
                   notificationsEmail:
                     description: Notification email plugin information
                     properties:
@@ -403,14 +379,6 @@ spec:
                           secret to enable. See value backstage-backend-auth-secret.
                           See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
                         type: boolean
-                      integrity:
-                        default: sha512-sm7yRoO6Nkk3B7+AWKb10maIrb2YBNSiqQaWmFDVg2G9cbDoWr9wigqqeQ32+b6o2FenfNWg8xKY6PPyZGh8BA==
-                        description: Package SHA integrity
-                        type: string
-                      package:
-                        default: plugin-notifications-backend-module-email-dynamic@1.3.0
-                        description: Package name
-                        type: string
                       port:
                         default: 587
                         description: SMTP server port
@@ -459,30 +427,6 @@ spec:
                     default: '@redhat'
                     description: Scope of the plugins
                     type: string
-                  signals:
-                    description: Signals plugin information
-                    properties:
-                      integrity:
-                        default: sha512-+E8XeTXcG5oy+aNImGj/MY0dvEkP7XAsu4xuZjmAqOHyVfiIi0jnP/QDz8XMbD1IjCimbr/DMUZdjmzQiD0hSQ==
-                        description: Package SHA integrity
-                        type: string
-                      package:
-                        default: plugin-signals-dynamic@1.3.0
-                        description: Package name
-                        type: string
-                    type: object
-                  signalsBackend:
-                    description: Signals backend plugin information
-                    properties:
-                      integrity:
-                        default: sha512-5Bl6C+idPXtquQxMZW+bjRMcOfFYcKxcGZZFv2ITkPVeY2zzxQnAz3vYHnbvKRSwlQxjIyRXY6YgITGHXWT0nw==
-                        description: Package SHA integrity
-                        type: string
-                      package:
-                        default: plugin-signals-backend-dynamic@1.3.0
-                        description: Package name
-                        type: string
-                    type: object
                 type: object
               serverlessOperator:
                 properties:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -12,14 +12,16 @@ spec:
     singular: orchestrator
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[-1:].reason
-      name: Reason
-      type: string
-    name: v1alpha1
+  - name: v1alpha2
+    served: true
+    storage: true
+    additionalPrinterColumns:
+      - jsonPath: .status.conditions[-1:].status
+        name: Ready
+        type: string
+      - jsonPath: .status.conditions[-1:].reason
+        name: Reason
+        type: string
     schema:
       openAPIV3Schema:
         description: Orchestrator is the Schema for the orchestrators API
@@ -297,54 +299,6 @@ spec:
                         type: string
                         default: sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==
                     type: object
-                  notifications:
-                    description: Notification plugin information
-                    properties:
-                      package:
-                        description: Package name
-                        type: string
-                        default: plugin-notifications-dynamic@1.3.0
-                      integrity:
-                        description: Package SHA integrity
-                        type: string
-                        default: sha512-iYLgIy0YdP/CdTLol07Fncmo9n0J8PdIZseiwAyUt9RFJzKIXmoi2CpQLPKMx36lEgPYUlT0rFO81Ie2CSis4Q==
-                    type: object
-                  notificationsBackend:
-                    description: Notification backend plugin information
-                    properties:
-                      package:
-                        description: Package name
-                        type: string
-                        default: plugin-notifications-backend-dynamic@1.3.0
-                      integrity:
-                        description: Package SHA integrity
-                        type: string
-                        default: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==
-                    type: object
-                  signals:
-                    description: Signals plugin information
-                    properties:
-                      package:
-                        description: Package name
-                        type: string
-                        default: plugin-signals-dynamic@1.3.0
-                      integrity:
-                        description: Package SHA integrity
-                        type: string
-                        default: sha512-+E8XeTXcG5oy+aNImGj/MY0dvEkP7XAsu4xuZjmAqOHyVfiIi0jnP/QDz8XMbD1IjCimbr/DMUZdjmzQiD0hSQ==
-                    type: object
-                  signalsBackend:
-                    description: Signals backend plugin information
-                    properties:
-                      package:
-                        description: Package name
-                        type: string
-                        default: plugin-signals-backend-dynamic@1.3.0
-                      integrity:
-                        description: Package SHA integrity
-                        type: string
-                        default: sha512-5Bl6C+idPXtquQxMZW+bjRMcOfFYcKxcGZZFv2ITkPVeY2zzxQnAz3vYHnbvKRSwlQxjIyRXY6YgITGHXWT0nw==
-                    type: object
                   notificationsEmail:
                     description: Notification email plugin information
                     properties:
@@ -352,14 +306,6 @@ spec:
                         description: whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
                         type: boolean
                         default: false
-                      package:
-                        description: Package name
-                        type: string
-                        default: plugin-notifications-backend-module-email-dynamic@1.3.0
-                      integrity:
-                        description: Package SHA integrity
-                        type: string
-                        default: sha512-sm7yRoO6Nkk3B7+AWKb10maIrb2YBNSiqQaWmFDVg2G9cbDoWr9wigqqeQ32+b6o2FenfNWg8xKY6PPyZGh8BA==
                       port:
                         description: SMTP server port
                         type: integer
@@ -490,7 +436,5 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
-    served: true
-    storage: true
     subresources:
       status: {}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,7 @@ spec:
       - args:
         - --leader-elect
         - --leader-election-id=orchestrator-operator
+        - --api-version=rhdh.redhat.com/v1alpha2
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manifests/bases/orchestrator-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/orchestrator-operator.clusterserviceversion.yaml
@@ -40,7 +40,7 @@ spec:
       displayName: Orchestrator
       kind: Orchestrator
       name: orchestrators.rhdh.redhat.com
-      version: v1alpha1
+      version: v1alpha2
   description: |
     Red Hat Developer Hub Orchestrator is a plugin that enables serverless asynchronous workflows to Backstage.
 
@@ -80,4 +80,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.2.0
+  version: 1.3.0

--- a/config/samples/_v1alpha2_orchestrator.yaml
+++ b/config/samples/_v1alpha2_orchestrator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rhdh.redhat.com/v1alpha1
+apiVersion: rhdh.redhat.com/v1alpha2
 kind: Orchestrator
 metadata:
   name: orchestrator-sample
@@ -59,24 +59,10 @@ spec:
       package: "backstage-plugin-orchestrator@1.3.0"
       integrity: sha512-A/twx1SOOGDQjglLzOxQikKO0XOdPP1jh2lj9Y/92bLox8mT+eaZpub8YLwR2mb7LsUIUImg+U6VnKwoAV9ATA==
     orchestratorBackend:
-      package: "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
-      integrity: sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==
-    notifications:
-      package: "plugin-notifications-dynamic@1.3.0"
-      integrity: sha512-iYLgIy0YdP/CdTLol07Fncmo9n0J8PdIZseiwAyUt9RFJzKIXmoi2CpQLPKMx36lEgPYUlT0rFO81Ie2CSis4Q==
-    notificationsBackend:
-      package: "plugin-notifications-backend-dynamic@1.3.0"
-      integrity: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==
-    signals:
-      package: "plugin-signals-dynamic@1.3.0"
-      integrity: sha512-+E8XeTXcG5oy+aNImGj/MY0dvEkP7XAsu4xuZjmAqOHyVfiIi0jnP/QDz8XMbD1IjCimbr/DMUZdjmzQiD0hSQ==
-    signalsBackend:
-      package: "plugin-signals-backend-dynamic@1.3.0"
-      integrity: sha512-5Bl6C+idPXtquQxMZW+bjRMcOfFYcKxcGZZFv2ITkPVeY2zzxQnAz3vYHnbvKRSwlQxjIyRXY6YgITGHXWT0nw==
+    package: "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
+    integrity: sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==
     notificationsEmail:
       enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
-      package: "plugin-notifications-backend-module-email-dynamic@1.3.0"
-      integrity: sha512-sm7yRoO6Nkk3B7+AWKb10maIrb2YBNSiqQaWmFDVg2G9cbDoWr9wigqqeQ32+b6o2FenfNWg8xKY6PPyZGh8BA==
       port: 587 # SMTP server port
       sender: "" # the email sender address
       replyTo: "" # reply-to address

--- a/config/samples/_v1alpha2_orchestrator.yaml
+++ b/config/samples/_v1alpha2_orchestrator.yaml
@@ -59,8 +59,8 @@ spec:
       package: "backstage-plugin-orchestrator@1.3.0"
       integrity: sha512-A/twx1SOOGDQjglLzOxQikKO0XOdPP1jh2lj9Y/92bLox8mT+eaZpub8YLwR2mb7LsUIUImg+U6VnKwoAV9ATA==
     orchestratorBackend:
-    package: "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
-    integrity: sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==
+      package: "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
+      integrity: sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==
     notificationsEmail:
       enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
       port: 587 # SMTP server port

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples of your project ##
 resources:
-- _v1alpha1_orchestrator.yaml
+- _v1alpha2_orchestrator.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -138,7 +138,7 @@ To include the Notification Plugin append this configuration to the ConfigMap:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              backstage.plugin-notifications:
+              redhat.plugin-notifications:
                 dynamicRoutes:
                   - importName: NotificationsPage
                     menuItem:
@@ -154,7 +154,7 @@ To include the Notification Plugin append this configuration to the ConfigMap:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              backstage.plugin-signals: {}
+              redhat.plugin-signals: {}
       - disabled: false
         package: "@redhat/plugin-notifications-backend-dynamic@1.3.0"
         integrity: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -115,7 +115,7 @@ By default it should point to `http://sonataflow-platform-data-index-service.son
         pluginConfig:
           dynamicPlugins:
             frontend:
-              red-hat-developer-hub.backstage-plugin-orchestrator:
+              janus-idp.backstage-plugin-orchestrator:
                 appIcons:
                   - importName: OrchestratorIcon
                     module: OrchestratorPlugin

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -115,7 +115,7 @@ By default it should point to `http://sonataflow-platform-data-index-service.son
         pluginConfig:
           dynamicPlugins:
             frontend:
-               red-hat-developer-hub.backstage-plugin-orchestrator:
+              red-hat-developer-hub.backstage-plugin-orchestrator:
                 appIcons:
                   - importName: OrchestratorIcon
                     module: OrchestratorPlugin
@@ -138,7 +138,7 @@ To include the Notification Plugin append this configuration to the ConfigMap:
         pluginConfig:
           dynamicPlugins:
             frontend:
-               backstage.plugin-notifications:
+              backstage.plugin-notifications:
                 dynamicRoutes:
                   - importName: NotificationsPage
                     menuItem:
@@ -154,7 +154,7 @@ To include the Notification Plugin append this configuration to the ConfigMap:
         pluginConfig:
           dynamicPlugins:
             frontend:
-               backstage.plugin-signals: {}
+              backstage.plugin-signals: {}
       - disabled: false
         package: "@redhat/plugin-notifications-backend-dynamic@1.3.0"
         integrity: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -115,7 +115,7 @@ By default it should point to `http://sonataflow-platform-data-index-service.son
         pluginConfig:
           dynamicPlugins:
             frontend:
-              janus-idp.backstage-plugin-orchestrator:
+               red-hat-developer-hub.backstage-plugin-orchestrator:
                 appIcons:
                   - importName: OrchestratorIcon
                     module: OrchestratorPlugin
@@ -138,7 +138,7 @@ To include the Notification Plugin append this configuration to the ConfigMap:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              redhat.plugin-notifications:
+               backstage.plugin-notifications:
                 dynamicRoutes:
                   - importName: NotificationsPage
                     menuItem:
@@ -154,7 +154,7 @@ To include the Notification Plugin append this configuration to the ConfigMap:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              redhat.plugin-signals: {}
+               backstage.plugin-signals: {}
       - disabled: false
         package: "@redhat/plugin-notifications-backend-dynamic@1.3.0"
         integrity: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==

--- a/helm-charts/orchestrator/templates/rhdh-operator.yaml
+++ b/helm-charts/orchestrator/templates/rhdh-operator.yaml
@@ -206,7 +206,7 @@ data:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              backstage.plugin-notifications:
+              redhat.plugin-notifications:
                 dynamicRoutes:
                   - importName: NotificationsPage
                     menuItem:
@@ -221,7 +221,7 @@ data:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              backstage.plugin-signals: {}
+              redhat.plugin-signals: {}
       - disabled: false
         package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
       - disabled: false

--- a/helm-charts/orchestrator/templates/rhdh-operator.yaml
+++ b/helm-charts/orchestrator/templates/rhdh-operator.yaml
@@ -202,8 +202,7 @@ data:
                     module: OrchestratorPlugin
                     path: /orchestrator
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notifications.package }}"
-        integrity: {{ .Values.rhdhPlugins.notifications.integrity }}
+        package: ./dynamic-plugins/dist/backstage-plugin-notifications
         pluginConfig:
           dynamicPlugins:
             frontend:
@@ -218,26 +217,22 @@ data:
                       importName: NotificationsSidebarItem
                     path: /notifications
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signals.package }}"
-        integrity: {{ .Values.rhdhPlugins.signals.integrity }}
+        package: ./dynamic-plugins/dist/backstage-plugin-signals
         pluginConfig:
           dynamicPlugins:
             frontend:
               redhat.plugin-signals: {}
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notificationsBackend.package }}"
-        integrity: {{ .Values.rhdhPlugins.notificationsBackend.integrity }}
+        package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signalsBackend.package }}"
-        integrity: {{ .Values.rhdhPlugins.signalsBackend.integrity }}
+        package: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
       - disabled: false
         package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
   {{- if and .Values.rhdhPlugins.notificationsEmail.enabled
         ( and (.Values.rhdhOperator.secretRef.notificationsEmail.hostname) (dig "data" .Values.rhdhOperator.secretRef.notificationsEmail.hostname "" $secret ) )
   }}
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notificationsEmail.package }}"
-        integrity: {{ .Values.rhdhPlugins.notificationsEmail.integrity }}
+        package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-module-email-dynamic
         pluginConfig:
           notifications:
             processors:

--- a/helm-charts/orchestrator/templates/rhdh-operator.yaml
+++ b/helm-charts/orchestrator/templates/rhdh-operator.yaml
@@ -189,7 +189,7 @@ data:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              janus-idp.backstage-plugin-orchestrator:
+              red-hat-developer-hub.backstage-plugin-orchestrator:
                 appIcons:
                   - importName: OrchestratorIcon
                     module: OrchestratorPlugin
@@ -206,7 +206,7 @@ data:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              redhat.plugin-notifications:
+              backstage.plugin-notifications:
                 dynamicRoutes:
                   - importName: NotificationsPage
                     menuItem:
@@ -221,7 +221,7 @@ data:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              redhat.plugin-signals: {}
+              backstage.plugin-signals: {}
       - disabled: false
         package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
       - disabled: false

--- a/helm-charts/orchestrator/templates/rhdh-operator.yaml
+++ b/helm-charts/orchestrator/templates/rhdh-operator.yaml
@@ -189,7 +189,7 @@ data:
         pluginConfig:
           dynamicPlugins:
             frontend:
-              red-hat-developer-hub.backstage-plugin-orchestrator:
+              janus-idp.backstage-plugin-orchestrator:
                 appIcons:
                   - importName: OrchestratorIcon
                     module: OrchestratorPlugin

--- a/helm-charts/orchestrator/values.schema.json
+++ b/helm-charts/orchestrator/values.schema.json
@@ -616,10 +616,6 @@
                 "scope",
                 "orchestrator",
                 "orchestratorBackend",
-                "notifications",
-                "notificationsBackend",
-                "signals",
-                "signalsBackend",
                 "notificationsEmail"
             ],
             "properties": {
@@ -701,138 +697,12 @@
                         "integrity": "sha512-lyw7IHuXsakTa5Pok8S2GK0imqrmXe3z+TcL7eB2sJYFqQPkCP5la1vqteL9/1EaI5eI6nKZ60WVRkPEldKBTg=="
                     }]
                 },
-                "notifications": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The notifications Schema",
-                    "required": [
-                        "package",
-                        "integrity"
-                    ],
-                    "properties": {
-                        "package": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The package Schema",
-                            "examples": [
-                                "plugin-notifications-dynamic@1.2.0"
-                            ]
-                        },
-                        "integrity": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The integrity Schema",
-                            "examples": [
-                                "sha512-1mhUl14v+x0Ta1o8Sp4KBa02izGXHd+wsiCVsDP/th6yWDFJsfSMf/DyMIn1Uhat1rQgVFRUMg8QgrvbgZCR/w=="
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "package": "plugin-notifications-dynamic@1.2.0",
-                        "integrity": "sha512-1mhUl14v+x0Ta1o8Sp4KBa02izGXHd+wsiCVsDP/th6yWDFJsfSMf/DyMIn1Uhat1rQgVFRUMg8QgrvbgZCR/w=="
-                    }]
-                },
-                "notificationsBackend": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The notificationsBackend Schema",
-                    "required": [
-                        "package",
-                        "integrity"
-                    ],
-                    "properties": {
-                        "package": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The package Schema",
-                            "examples": [
-                                "plugin-notifications-backend-dynamic@1.2.0"
-                            ]
-                        },
-                        "integrity": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The integrity Schema",
-                            "examples": [
-                                "sha512-pCFB/jZIG/Ip1wp67G0ZDJPp63E+aw66TX1rPiuSAbGSn+Mcnl8g+XlHLOMMTz+NPloHwj2/Tp4fSf59w/IOSw=="
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "package": "plugin-notifications-backend-dynamic@1.2.0",
-                        "integrity": "sha512-pCFB/jZIG/Ip1wp67G0ZDJPp63E+aw66TX1rPiuSAbGSn+Mcnl8g+XlHLOMMTz+NPloHwj2/Tp4fSf59w/IOSw=="
-                    }]
-                },
-                "signals": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The signals Schema",
-                    "required": [
-                        "package",
-                        "integrity"
-                    ],
-                    "properties": {
-                        "package": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The package Schema",
-                            "examples": [
-                                "plugin-signals-dynamic@1.2.0"
-                            ]
-                        },
-                        "integrity": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The integrity Schema",
-                            "examples": [
-                                "sha512-5tbZyRob0JDdrI97HXb7JqFIzNho1l7JuIkob66J+ZMAPCit+pjN1CUuPbpcglKyyIzULxq63jMBWONxcqNSXw=="
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "package": "plugin-signals-dynamic@1.2.0",
-                        "integrity": "sha512-5tbZyRob0JDdrI97HXb7JqFIzNho1l7JuIkob66J+ZMAPCit+pjN1CUuPbpcglKyyIzULxq63jMBWONxcqNSXw=="
-                    }]
-                },
-                "signalsBackend": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The signalsBackend Schema",
-                    "required": [
-                        "package",
-                        "integrity"
-                    ],
-                    "properties": {
-                        "package": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The package Schema",
-                            "examples": [
-                                "plugin-signals-backend-dynamic@1.2.0"
-                            ]
-                        },
-                        "integrity": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The integrity Schema",
-                            "examples": [
-                                "sha512-DIISzxtjeJ4a9mX3TLcuGcavRHbCtQ5b52wHn+9+uENUL2IDbFoqmB4/9BQASaKIUSFkRKLYpc5doIkrnTVyrA=="
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "package": "plugin-signals-backend-dynamic@1.2.0",
-                        "integrity": "sha512-DIISzxtjeJ4a9mX3TLcuGcavRHbCtQ5b52wHn+9+uENUL2IDbFoqmB4/9BQASaKIUSFkRKLYpc5doIkrnTVyrA=="
-                    }]
-                },
                 "notificationsEmail": {
                     "type": "object",
                     "default": {},
                     "title": "The notificationsEmail Schema",
                     "required": [
                         "enabled",
-                        "package",
-                        "integrity",
                         "port",
                         "sender",
                         "replyTo"
@@ -908,26 +778,8 @@
                     "package": "backstage-plugin-orchestrator-backend-dynamic@1.2.0",
                     "integrity": "sha512-lyw7IHuXsakTa5Pok8S2GK0imqrmXe3z+TcL7eB2sJYFqQPkCP5la1vqteL9/1EaI5eI6nKZ60WVRkPEldKBTg=="
                 },
-                "notifications": {
-                    "package": "plugin-notifications-dynamic@1.2.0",
-                    "integrity": "sha512-1mhUl14v+x0Ta1o8Sp4KBa02izGXHd+wsiCVsDP/th6yWDFJsfSMf/DyMIn1Uhat1rQgVFRUMg8QgrvbgZCR/w=="
-                },
-                "notificationsBackend": {
-                    "package": "plugin-notifications-backend-dynamic@1.2.0",
-                    "integrity": "sha512-pCFB/jZIG/Ip1wp67G0ZDJPp63E+aw66TX1rPiuSAbGSn+Mcnl8g+XlHLOMMTz+NPloHwj2/Tp4fSf59w/IOSw=="
-                },
-                "signals": {
-                    "package": "plugin-signals-dynamic@1.2.0",
-                    "integrity": "sha512-5tbZyRob0JDdrI97HXb7JqFIzNho1l7JuIkob66J+ZMAPCit+pjN1CUuPbpcglKyyIzULxq63jMBWONxcqNSXw=="
-                },
-                "signalsBackend": {
-                    "package": "plugin-signals-backend-dynamic@1.2.0",
-                    "integrity": "sha512-DIISzxtjeJ4a9mX3TLcuGcavRHbCtQ5b52wHn+9+uENUL2IDbFoqmB4/9BQASaKIUSFkRKLYpc5doIkrnTVyrA=="
-                },
                 "notificationsEmail": {
                     "enabled": false,
-                    "package": "plugin-notifications-backend-module-email-dynamic@1.2.0",
-                    "integrity": "sha512-dtmliahV5+xtqvwdxP2jvyzd5oXTbv6lvS3c9nR8suqxTullxxj0GFg1uU2SQ2uKBQWhOz8YhSmrRwxxLa9Zqg==",
                     "port": 587,
                     "sender": "",
                     "replyTo": ""
@@ -1309,26 +1161,8 @@
                 "package": "backstage-plugin-orchestrator-backend-dynamic@1.2.0",
                 "integrity": "sha512-lyw7IHuXsakTa5Pok8S2GK0imqrmXe3z+TcL7eB2sJYFqQPkCP5la1vqteL9/1EaI5eI6nKZ60WVRkPEldKBTg=="
             },
-            "notifications": {
-                "package": "plugin-notifications-dynamic@1.2.0",
-                "integrity": "sha512-1mhUl14v+x0Ta1o8Sp4KBa02izGXHd+wsiCVsDP/th6yWDFJsfSMf/DyMIn1Uhat1rQgVFRUMg8QgrvbgZCR/w=="
-            },
-            "notificationsBackend": {
-                "package": "plugin-notifications-backend-dynamic@1.2.0",
-                "integrity": "sha512-pCFB/jZIG/Ip1wp67G0ZDJPp63E+aw66TX1rPiuSAbGSn+Mcnl8g+XlHLOMMTz+NPloHwj2/Tp4fSf59w/IOSw=="
-            },
-            "signals": {
-                "package": "plugin-signals-dynamic@1.2.0",
-                "integrity": "sha512-5tbZyRob0JDdrI97HXb7JqFIzNho1l7JuIkob66J+ZMAPCit+pjN1CUuPbpcglKyyIzULxq63jMBWONxcqNSXw=="
-            },
-            "signalsBackend": {
-                "package": "plugin-signals-backend-dynamic@1.2.0",
-                "integrity": "sha512-DIISzxtjeJ4a9mX3TLcuGcavRHbCtQ5b52wHn+9+uENUL2IDbFoqmB4/9BQASaKIUSFkRKLYpc5doIkrnTVyrA=="
-            },
             "notificationsEmail": {
                 "enabled": false,
-                "package": "plugin-notifications-backend-module-email-dynamic@1.2.0",
-                "integrity": "sha512-dtmliahV5+xtqvwdxP2jvyzd5oXTbv6lvS3c9nR8suqxTullxxj0GFg1uU2SQ2uKBQWhOz8YhSmrRwxxLa9Zqg==",
                 "port": 587,
                 "sender": "",
                 "replyTo": ""

--- a/helm-charts/orchestrator/values.yaml
+++ b/helm-charts/orchestrator/values.yaml
@@ -61,22 +61,8 @@ rhdhPlugins: # RHDH plugins required for the Orchestrator
   orchestratorBackend:
     package: "backstage-plugin-orchestrator-backend-dynamic@1.3.0"
     integrity: sha512-Th5vmwyhHyhURwQo28++PPHTvxGSFScSHPJyofIdE5gTAb87ncyfyBkipSDq7fwj4L8CQTXa4YP6A2EkHW1npg==
-  notifications:
-    package: "plugin-notifications-dynamic@1.3.0"
-    integrity: sha512-iYLgIy0YdP/CdTLol07Fncmo9n0J8PdIZseiwAyUt9RFJzKIXmoi2CpQLPKMx36lEgPYUlT0rFO81Ie2CSis4Q==
-  notificationsBackend:
-    package: "plugin-notifications-backend-dynamic@1.3.0"
-    integrity: sha512-Pw9Op/Q+1MctmLiVvQ3M+89tkbWkw8Lw0VfcwyGSMiHpK/Xql1TrSFtThtLlymRgeCSBgxHYhh3MUusNQX08VA==
-  signals:
-    package: "plugin-signals-dynamic@1.3.0"
-    integrity: sha512-+E8XeTXcG5oy+aNImGj/MY0dvEkP7XAsu4xuZjmAqOHyVfiIi0jnP/QDz8XMbD1IjCimbr/DMUZdjmzQiD0hSQ==
-  signalsBackend:
-    package: "plugin-signals-backend-dynamic@1.3.0"
-    integrity: sha512-5Bl6C+idPXtquQxMZW+bjRMcOfFYcKxcGZZFv2ITkPVeY2zzxQnAz3vYHnbvKRSwlQxjIyRXY6YgITGHXWT0nw==
   notificationsEmail:
     enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
-    package: "plugin-notifications-backend-module-email-dynamic@1.3.0"
-    integrity: sha512-sm7yRoO6Nkk3B7+AWKb10maIrb2YBNSiqQaWmFDVg2G9cbDoWr9wigqqeQ32+b6o2FenfNWg8xKY6PPyZGh8BA==
     port: 587 # SMTP server port
     sender: "" # the email sender address
     replyTo: "" # reply-to address

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,6 +1,6 @@
 # Use the 'create api' subcommand to add watches to this file.
 - group: rhdh.redhat.com
-  version: v1alpha1
+  version: v1alpha2
   kind: Orchestrator
   chart: helm-charts/orchestrator
   dryRunOption: server


### PR DESCRIPTION
With the recent changes to RHDH plugins, we are now enabling the notifications, notifications-backend and notificatinemail plugins and signals/signal backends plugins by default. Hence no longer allowing the admin to configure these values via the CR/CRD. As this is a breaking change, we introduce the v1alpha2 version of the CRD, remove these values from the CRD and `values.yaml` files. We also added the new custom plugins orchestrator.

- Updated rhdh-operator manifest using [this](https://github.com/batzionb/orchestrator-helm-operator/commit/78f089443e7bf993757d1fb5721d7d0e24c8aa6a) example
