### PR TITLE
Updated orchestrator plugins to rc4

### DIFF
--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -98,14 +98,14 @@ metadata:
               },
               "npmRegistry": "https://npm.registry.redhat.com",
               "orchestrator": {
-                "integrity": "sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==",
-                "package": "backstage-plugin-orchestrator@1.4.0-rc.3"
+                "integrity": "sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==",
+                "package": "backstage-plugin-orchestrator-1.4.0-rc.4.tgz"
               },
               "orchestratorBackend": {
-                "integrity": "sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==",
-                "package": "backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.3"
+                "integrity": "sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==",
+                "package": "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz"
               },
-              "scope": "@redhat"
+              "scope": "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
             },
             "serverlessOperator": {
               "enabled": true,

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -433,11 +433,11 @@ spec:
                     description: Orchestrator plugin information
                     properties:
                       integrity:
-                        default: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+                        default: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: backstage-plugin-orchestrator@1.4.0-rc.3
+                        default: backstage-plugin-orchestrator-1.4.0-rc.4.tgz
                         description: Package name
                         type: string
                     type: object
@@ -445,16 +445,16 @@ spec:
                     description: Orchestrator backend plugin information
                     properties:
                       integrity:
-                        default: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+                        default: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.3
+                        default: backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz
                         description: Package name
                         type: string
                     type: object
                   scope:
-                    default: '@redhat'
+                    default: 'https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4'
                     description: Scope of the plugins
                     type: string
                 type: object

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -285,18 +285,18 @@ spec:
                     type: string
                   scope:
                     description: Scope of the plugins
-                    default: "@redhat"
+                    default: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
                     type: string
                   orchestrator:
                     description: Orchestrator plugin information
                     properties:
                       package:
                         description: Package name
-                        default: backstage-plugin-orchestrator@1.4.0-rc.3
+                        default: backstage-plugin-orchestrator-1.4.0-rc.4.tgz
                         type: string
                       integrity:
                         description: Package SHA integrity
-                        default: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+                        default: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
                         type: string
                     type: object
                   orchestratorBackend:
@@ -305,11 +305,11 @@ spec:
                       package:
                         description: Package name
                         type: string
-                        default: backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.3
+                        default: backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz
                       integrity:
                         description: Package SHA integrity
                         type: string
-                        default: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+                        default: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
                     type: object
                   notificationsEmail:
                     description: Notification email plugin information

--- a/config/samples/_v1alpha2_orchestrator.yaml
+++ b/config/samples/_v1alpha2_orchestrator.yaml
@@ -57,13 +57,13 @@ spec:
       targetNamespace: rhdh-operator # the target namespace for the backstage CR in which RHDH instance is created
   rhdhPlugins: # RHDH plugins required for the Orchestrator
     npmRegistry: "https://npm.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
-    scope: "@redhat"
+    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
     orchestrator:
-      package: "backstage-plugin-orchestrator@1.4.0-rc.3"
-      integrity: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+      package: "backstage-plugin-orchestrator-1.4.0-rc.4.tgz"
+      integrity: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
     orchestratorBackend:
-      package: "backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.3"
-      integrity: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+      package: "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz"
+      integrity: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
     notificationsEmail:
       enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
       port: 587 # SMTP server port

--- a/helm-charts/orchestrator/values.yaml
+++ b/helm-charts/orchestrator/values.yaml
@@ -57,13 +57,13 @@ rhdhOperator:
 
 rhdhPlugins: # RHDH plugins required for the Orchestrator
   npmRegistry: "https://npm.stage.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
-  scope: "@redhat"
+  scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
   orchestrator:
-    package: "backstage-plugin-orchestrator@1.4.0-rc.3"
-    integrity: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+    package: "backstage-plugin-orchestrator-1.4.0-rc.4.tgz"
+    integrity: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
   orchestratorBackend:
-    package: "backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.3"
-    integrity: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+    package: "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz"
+    integrity: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
   notificationsEmail:
     enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
     port: 587 # SMTP server port


### PR DESCRIPTION
Updated the orchestrator plugins to rc4 using github release configurations.

```
https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4/backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz
sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==

https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4/backstage-plugin-orchestrator-1.4.0-rc.4.tgz
sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
```