### PR TITLE
bumping osl version for kn-cli

### DIFF
--- a/helm-charts/orchestrator/templates/tekton-tasks.yaml
+++ b/helm-charts/orchestrator/templates/tekton-tasks.yaml
@@ -215,7 +215,7 @@ spec:
       workingDir: $(workspaces.workflow-source.path)/flat/$(params.workflowId)
       script: |
         microdnf install -y tar gzip
-        KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.33.0/kn-workflow-linux-amd64.tar.gz"
+        KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.35.0/kn-workflow-linux-amd64.tar.gz"
         curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-workflow-linux-amd64 && mv kn-workflow-linux-amd64 kn-workflow
         ./kn-workflow gen-manifest --namespace ""
 ---


### PR DESCRIPTION
The kn-cli version being used in the tekton pipline is outdated. We need to update that so that the generated manifests created by the tekton pipeline will be in the format that OSL 1.35 expects them to be in (e.g has the flow tag) 
related to bug [TO BE OPENED] 