### PR TITLE
Orchestrator Plugins 1.4.0-rc.7

### DIFF
--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -139,7 +139,7 @@ metadata:
     capabilities: Basic Install
     categories: Developer Tools
     console.openshift.io/disable-operand-delete: "true"
-    createdAt: "2025-01-30T15:22:24Z"
+    createdAt: "2025-01-30T16:15:30Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -98,14 +98,14 @@ metadata:
               },
               "npmRegistry": "https://npm.registry.redhat.com",
               "orchestrator": {
-                "integrity": "sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==",
-                "package": "backstage-plugin-orchestrator-1.4.0-rc.4.tgz"
+                "integrity": "sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==",
+                "package": "backstage-plugin-orchestrator-1.4.0-rc.7.tgz"
               },
               "orchestratorBackend": {
-                "integrity": "sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==",
-                "package": "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz"
+                "integrity": "sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==",
+                "package": "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.7.tgz"
               },
-              "scope": "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
+              "scope": "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7"
             },
             "serverlessOperator": {
               "enabled": true,
@@ -139,7 +139,7 @@ metadata:
     capabilities: Basic Install
     categories: Developer Tools
     console.openshift.io/disable-operand-delete: "true"
-    createdAt: "2025-01-29T14:27:58Z"
+    createdAt: "2025-01-30T15:22:24Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -447,11 +447,11 @@ spec:
                     description: Orchestrator plugin information
                     properties:
                       integrity:
-                        default: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
+                        default: sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: backstage-plugin-orchestrator-1.4.0-rc.4.tgz
+                        default: backstage-plugin-orchestrator-1.4.0-rc.7.tgz
                         description: Package name
                         type: string
                     type: object
@@ -459,16 +459,16 @@ spec:
                     description: Orchestrator backend plugin information
                     properties:
                       integrity:
-                        default: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
+                        default: sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==
                         description: Package SHA integrity
                         type: string
                       package:
-                        default: backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz
+                        default: backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.7.tgz
                         description: Package name
                         type: string
                     type: object
                   scope:
-                    default: 'https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4'
+                    default: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7
                     description: Scope of the plugins
                     type: string
                 type: object

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -285,18 +285,18 @@ spec:
                     type: string
                   scope:
                     description: Scope of the plugins
-                    default: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
+                    default: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7"
                     type: string
                   orchestrator:
                     description: Orchestrator plugin information
                     properties:
                       package:
                         description: Package name
-                        default: backstage-plugin-orchestrator-1.4.0-rc.4.tgz
+                        default: backstage-plugin-orchestrator-1.4.0-rc.7.tgz
                         type: string
                       integrity:
                         description: Package SHA integrity
-                        default: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
+                        default: sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==
                         type: string
                     type: object
                   orchestratorBackend:
@@ -305,11 +305,11 @@ spec:
                       package:
                         description: Package name
                         type: string
-                        default: backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz
+                        default: backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.7.tgz
                       integrity:
                         description: Package SHA integrity
                         type: string
-                        default: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
+                        default: sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==
                     type: object
                   notificationsEmail:
                     description: Notification email plugin information

--- a/config/samples/_v1alpha2_orchestrator.yaml
+++ b/config/samples/_v1alpha2_orchestrator.yaml
@@ -58,13 +58,13 @@ spec:
       targetNamespace: rhdh-operator # the target namespace for the backstage CR in which RHDH instance is created
   rhdhPlugins: # RHDH plugins required for the Orchestrator
     npmRegistry: "https://npm.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
-    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
+    scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7"
     orchestrator:
-      package: "backstage-plugin-orchestrator-1.4.0-rc.4.tgz"
-      integrity: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
+      package: "backstage-plugin-orchestrator-1.4.0-rc.7.tgz"
+      integrity: sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==
     orchestratorBackend:
-      package: "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz"
-      integrity: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
+      package: "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.7.tgz"
+      integrity: sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==
     notificationsEmail:
       enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
       port: 587 # SMTP server port

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -103,15 +103,15 @@ By default it should point to `http://sonataflow-platform-data-index-service.son
   ```
 ```yaml
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.3"
-        integrity: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.7"
+        integrity: sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==
         pluginConfig:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service.sonataflow-infra
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator@1.4.0-rc.3"
-        integrity: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+        package: "@redhat/backstage-plugin-orchestrator@1.4.0-rc.7"
+        integrity: sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==
         pluginConfig:
           dynamicPlugins:
             frontend:

--- a/helm-charts/orchestrator/values.yaml
+++ b/helm-charts/orchestrator/values.yaml
@@ -57,14 +57,14 @@ rhdhOperator:
     targetNamespace: rhdh-operator # the target namespace for the backstage CR in which RHDH instance is created
 
 rhdhPlugins: # RHDH plugins required for the Orchestrator
-  npmRegistry: "https://npm.stage.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
-  scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.4"
+  npmRegistry: "" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories
+  scope: "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7"
   orchestrator:
-    package: "backstage-plugin-orchestrator-1.4.0-rc.4.tgz"
-    integrity: sha512-2Dp6E1i5bAfUnbUctmYnJGE9su5PgHWhFsOXvDYHYzccIy4fMlSrEkvIjrX8KXu+9PSM+FnYAZZ/13zNcsM+Og==
+    package: "backstage-plugin-orchestrator-1.4.0-rc.7.tgz"
+    integrity: sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==
   orchestratorBackend:
-    package: "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.4.tgz"
-    integrity: sha512-h3RNs965QFn/ldoBIKGKNP3Mb4i25uWn4bFUXLZ5f+XVxFmZ/9yf7Ue8sGQOXC5GyxRb8W9cA0zae48E9YCcyQ==
+    package: "backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.7.tgz"
+    integrity: sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==
   notificationsEmail:
     enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
     port: 587 # SMTP server port


### PR DESCRIPTION
Updated the orchestrator plugins to rc7 using github release configurations.
@mareklibra FYI

```
https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7/backstage-plugin-orchestrator-backend-dynamic-1.4.0-rc.7.tgz
sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==

https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.4.0-rc.7/backstage-plugin-orchestrator-1.4.0-rc.7.tgz
sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==
```