### PR TITLE
Fix advisory yq command to retrieve image pullspec and run skopeo 

### DIFF
--- a/docs/konflux/release_operator_with_konflux.md
+++ b/docs/konflux/release_operator_with_konflux.md
@@ -138,8 +138,8 @@ If the release fails, follow the [troubleshooting](#release-pipeline-failed) gui
 
 ```console
 advisoryURL=$(oc get $releaseName -ojsonpath='{.status.artifacts.advisory.url}' | sed  's/blob/raw/')
-controllerPullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("controller-rhel9-operator$") ))| .[].containerImage')
-bundlePullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("orchestrator-operator-bundle$") ))| .[].containerImage')
+controllerPullSpec=$(curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$controller_rhel9_operator'") | .containerImage')
+bundlePullSpec=$(curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$orchestrator_operator_bundle'") | .containerImage')
 skopeo inspect docker://$controllerPullSpec >/dev/null && echo "Controller image found in $controllerPullSpec" || echo "Controller image not found in $controllerPullSpec"
 skopeo inspect docker://$bundlePullSpec >/dev/null && echo "Bundle image found in $bundlePullSpec" || echo "Controller image not found in $bundlePullSpec"
 ```
@@ -351,8 +351,8 @@ If the release fails, follow the [troubleshooting](#release-pipeline-failed) gui
 
 ```console
 advisoryURL=$(oc get $releaseName -ojsonpath='{.status.artifacts.advisory.url}' | sed  's/blob/raw/')
-controllerPullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("controller-rhel9-operator$") ))| .[].containerImage')
-bundlePullSpec=$(curl $advisoryURL | yq '.spec.content[] | with_entries(select(.value.repository | test("orchestrator-operator-bundle$") ))| .[].containerImage')
+controllerPullSpec=$(curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$controller_rhel9_operator'") | .containerImage')
+bundlePullSpec=$(curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$orchestrator_operator_bundle'") | .containerImage')
 skopeo inspect docker://$controllerPullSpec >/dev/null && echo "Controller image found in $controllerPullSpec" || echo "Controller image not found in $controllerPullSpec"
 skopeo inspect docker://$bundlePullSpec >/dev/null && echo "Bundle image found in $bundlePullSpec" || echo "Controller image not found in $bundlePullSpec"
 ```


### PR DESCRIPTION
@gciavarrini @jenniferubah PTAL.

I noticed while running the release to production that the commands related to fetching the image pullspecs from the advisory were not working. I've reworked them so that they do now. Instead of searching for the image against the repository field, I use the `component` field which matches the env variable we define for each component, so the match is no longer a regex and we can do an equals. I think the outcome is better now that they look simpler. 

I don't know why it stopped working, it could be that there was a change int he status spec in the advisory manifest, but now they do:

```
$> echo $controller_rhel9_operator
controller-rhel9-operator-1-4
$> curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$controller_rhel9_operator'") | .containerImage'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2329  100  2329    0     0   2490      0 --:--:-- --:--:-- --:--:--  2490
registry.redhat.io/rhdh-orchestrator-dev-preview-beta/controller-rhel9-operator@sha256:22a6e6a593a3e92ac3951405832708f04237d32937209e378a25d54e6b69e512
```

And running the whole scriplet:

```bash
>$ advisoryURL=$(oc get $releaseName -ojsonpath='{.status.artifacts.advisory.url}' | sed  's/blob/raw/')
controllerPullSpec=$(curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$controller_rhel9_operator'") | .containerImage')
bundlePullSpec=$(curl $advisoryURL | yq -r  '.spec.content.images[] | select(.component=="'$orchestrator_operator_bundle'") | .containerImage')
skopeo inspect docker://$controllerPullSpec >/dev/null && echo "Controller image found in $controllerPullSpec" || echo "Controller image not found in $controllerPullSpec"
skopeo inspect docker://$bundlePullSpec >/dev/null && echo "Bundle image found in $bundlePullSpec" || echo "Controller image not found in $bundlePullSpec"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2329  100  2329    0     0   2288      0  0:00:01  0:00:01 --:--:--  2290
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2329  100  2329    0     0   2480      0 --:--:-- --:--:-- --:--:--  2480
Controller image found in registry.redhat.io/rhdh-orchestrator-dev-preview-beta/controller-rhel9-operator@sha256:22a6e6a593a3e92ac3951405832708f04237d32937209e378a25d54e6b69e512
Bundle image found in registry.redhat.io/rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle@sha256:e2d430161048239611b874a10376e7889d3cdd6f0368419e4bfba2d2c18dafd5
```