### PR TITLE
Revert "Updated tekton pipelines to point to 1.5 konflux components"

### DIFF
--- a/.tekton/controller-rhel9-operator-on-pull-request-1-4.yaml
+++ b/.tekton/controller-rhel9-operator-on-pull-request-1-4.yaml
@@ -4,15 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/rhdhorchestrator/orchestrator-helm-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ("Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "helm-charts/***".pathChanged() || ".tekton/controller-rhel9-operator-on-push-1-5.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ("Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "helm-charts/***".pathChanged() || ".tekton/controller-rhel9-operator-on-pull-request-1-4.yaml".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: helm-operator-1-5
-    appstudio.openshift.io/component: controller-rhel9-operator-1-5
+    appstudio.openshift.io/application: helm-operator-1-4
+    appstudio.openshift.io/component: controller-rhel9-operator-1-4
     pipelines.appstudio.openshift.io/type: build
-  name: controller-rhel9-operator-on-push-1-5
+  name: controller-rhel9-operator-on-pull-request-1-4
   namespace: orchestrator-releng-tenant
 spec:
   params:
@@ -21,7 +22,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/controller-rhel9-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/controller-rhel9-operator:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:

--- a/.tekton/controller-rhel9-operator-on-push-1-4.yaml
+++ b/.tekton/controller-rhel9-operator-on-push-1-4.yaml
@@ -4,16 +4,15 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/rhdhorchestrator/orchestrator-helm-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ("Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "helm-charts/***".pathChanged() || ".tekton/controller-rhel9-operator-on-pull-request-1-5.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ("Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "helm-charts/***".pathChanged() || ".tekton/controller-rhel9-operator-on-push-1-4.yaml".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: helm-operator-1-5
-    appstudio.openshift.io/component: controller-rhel9-operator-1-5
+    appstudio.openshift.io/application: helm-operator-1-4
+    appstudio.openshift.io/component: controller-rhel9-operator-1-4
     pipelines.appstudio.openshift.io/type: build
-  name: controller-rhel9-operator-on-pull-request-1-5
+  name: controller-rhel9-operator-on-push-1-4
   namespace: orchestrator-releng-tenant
 spec:
   params:
@@ -22,9 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/controller-rhel9-operator:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/controller-rhel9-operator:{{revision}}
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:

--- a/.tekton/orchestrator-operator-bundle-on-pull-request-1-4.yaml
+++ b/.tekton/orchestrator-operator-bundle-on-pull-request-1-4.yaml
@@ -4,15 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/rhdhorchestrator/orchestrator-helm-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "bundle/***".pathChanged() || ".tekton/orchestrator-operator-bundle-on-push-1-5.yaml".pathChanged() || "bundle.konflux.Dockerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "bundle/***".pathChanged() || ".tekton/orchestrator-operator-bundle-on-pull-request-1-4.yaml".pathChanged() || "bundle.konflux.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: helm-operator-1-5
-    appstudio.openshift.io/component: orchestrator-operator-bundle-1-5
+    appstudio.openshift.io/application: helm-operator-1-4
+    appstudio.openshift.io/component: orchestrator-operator-bundle-1-4
     pipelines.appstudio.openshift.io/type: build
-  name: orchestrator-operator-bundle-on-push-1-5
+  name: orchestrator-operator-bundle-on-pull-request-1-4
   namespace: orchestrator-releng-tenant
 spec:
   params:
@@ -21,7 +22,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/orchestrator-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/orchestrator-operator-bundle:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: bundle.konflux.Dockerfile
   pipelineSpec:

--- a/.tekton/orchestrator-operator-bundle-on-push-1-4.yaml
+++ b/.tekton/orchestrator-operator-bundle-on-push-1-4.yaml
@@ -4,16 +4,15 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/rhdhorchestrator/orchestrator-helm-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "bundle/***".pathChanged() || ".tekton/orchestrator-operator-bundle-on-pull-request-1-5.yaml".pathChanged() || "bundle.konflux.Dockerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "bundle/***".pathChanged() || ".tekton/orchestrator-operator-bundle-on-push-1-4.yaml".pathChanged() || "bundle.konflux.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: helm-operator-1-5
-    appstudio.openshift.io/component: orchestrator-operator-bundle-1-5
+    appstudio.openshift.io/application: helm-operator-1-4
+    appstudio.openshift.io/component: orchestrator-operator-bundle-1-4
     pipelines.appstudio.openshift.io/type: build
-  name: orchestrator-operator-bundle-on-pull-request-1-5
+  name: orchestrator-operator-bundle-on-push-1-4
   namespace: orchestrator-releng-tenant
 spec:
   params:
@@ -22,9 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/orchestrator-operator-bundle:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/orchestrator-releng-tenant/orchestrator-operator-bundle:{{revision}}
   - name: dockerfile
     value: bundle.konflux.Dockerfile
   pipelineSpec:


### PR DESCRIPTION
This reverts commit f71cc5ca0fafa1e514b4e70a284b4fe1ee85cd68.

Depends on https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/4830